### PR TITLE
[codex] Revive QiskitOpt on a reproducible Qiskit 2 stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,32 +4,25 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_dispatch:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - version: '1'
+          - version: '1.10'
             os: ubuntu-latest
-            arch: x64
-          - version: '1'
+          - version: '1.11'
+            os: ubuntu-latest
+          - version: '1.11'
             os: windows-latest
-            arch: x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-        env:
-          IBMQ_API_TOKEN: ${{ secrets.IBMQ_API_TOKEN }} 
-      # - uses: julia-actions/julia-processcoverage@v1
-      # - uses: codecov/codecov-action@v2
-      #   with:
-      #     file: lcov.info

--- a/.github/workflows/dependency-drift.yml
+++ b/.github/workflows/dependency-drift.yml
@@ -1,0 +1,20 @@
+name: Dependency Drift
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+jobs:
+  latest-compatible:
+    name: Latest Compatible Stack
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1.11"
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/ibm-hardware-smoke.yml
+++ b/.github/workflows/ibm-hardware-smoke.yml
@@ -1,0 +1,42 @@
+name: IBM Hardware Smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 10 1 * *"
+
+jobs:
+  smoke:
+    if: ${{ secrets.QISKIT_IBM_TOKEN != '' && secrets.QISKIT_IBM_INSTANCE != '' && vars.QISKIT_IBM_BACKEND != '' }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      QISKIT_IBM_TOKEN: ${{ secrets.QISKIT_IBM_TOKEN }}
+      QISKIT_IBM_INSTANCE: ${{ secrets.QISKIT_IBM_INSTANCE }}
+      QISKIT_IBM_CHANNEL: ${{ vars.QISKIT_IBM_CHANNEL }}
+      QISKIT_IBM_BACKEND: ${{ vars.QISKIT_IBM_BACKEND }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1.11"
+      - uses: julia-actions/julia-buildpkg@v1
+      - name: Run QAOA smoke test on IBM hardware
+        run: |
+          julia --project=. -e '
+          using JuMP
+          using QiskitOpt
+
+          model = Model(QiskitOpt.QAOA.Optimizer)
+
+          @variable(model, x[1:3], Bin)
+          @objective(model, Min, x[1] + x[2] + x[3] - 2x[1] * x[2] - 2x[2] * x[3])
+
+          set_attribute(model, QiskitOpt.QAOA.MaximumIterations(), 1)
+          set_attribute(model, QiskitOpt.QAOA.NumberOfReads(), 32)
+          set_attribute(model, QiskitOpt.QAOA.IBMBackend(), ENV["QISKIT_IBM_BACKEND"])
+
+          optimize!(model)
+          @assert result_count(model) >= 1
+          '

--- a/.github/workflows/ibm-hardware-smoke.yml
+++ b/.github/workflows/ibm-hardware-smoke.yml
@@ -35,20 +35,35 @@ jobs:
         if: steps.config.outputs.ready == 'true'
         run: |
           julia --project=. -e '
-          using JuMP
           using QiskitOpt
+          using QiskitOpt: QAOA, QUBODrivers
 
-          model = Model(QiskitOpt.QAOA.Optimizer)
+          MOI = QUBODrivers.MOI
+          model = MOI.instantiate(QAOA.Optimizer; with_cache_type=Float64)
+          x = MOI.add_variables(model, 3)
+          for variable in x
+              MOI.add_constraint(model, variable, MOI.ZeroOne())
+          end
 
-          @variable(model, x[1:3], Bin)
-          @objective(model, Min, x[1] + x[2] + x[3] - 2x[1] * x[2] - 2x[2] * x[3])
+          quadratic_terms = [
+              MOI.ScalarQuadraticTerm(-2.0, x[1], x[2]),
+              MOI.ScalarQuadraticTerm(-2.0, x[2], x[3]),
+          ]
+          linear_terms = [
+              MOI.ScalarAffineTerm(1.0, x[1]),
+              MOI.ScalarAffineTerm(1.0, x[2]),
+              MOI.ScalarAffineTerm(1.0, x[3]),
+          ]
+          objective = MOI.ScalarQuadraticFunction(quadratic_terms, linear_terms, 0.0)
+          MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+          MOI.set(model, MOI.ObjectiveFunction{typeof(objective)}(), objective)
 
-          set_attribute(model, QiskitOpt.QAOA.MaximumIterations(), 1)
-          set_attribute(model, QiskitOpt.QAOA.NumberOfReads(), 32)
-          set_attribute(model, QiskitOpt.QAOA.IBMBackend(), ENV["QISKIT_IBM_BACKEND"])
+          MOI.set(model, QAOA.MaximumIterations(), 1)
+          MOI.set(model, QAOA.NumberOfReads(), 32)
+          MOI.set(model, QAOA.IBMBackend(), ENV["QISKIT_IBM_BACKEND"])
 
-          optimize!(model)
-          @assert result_count(model) >= 1
+          MOI.optimize!(model)
+          @assert MOI.get(model, MOI.ResultCount()) >= 1
           '
       - name: Skip when IBM configuration is unavailable
         if: steps.config.outputs.ready != 'true'

--- a/.github/workflows/ibm-hardware-smoke.yml
+++ b/.github/workflows/ibm-hardware-smoke.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   smoke:
-    if: ${{ secrets.QISKIT_IBM_TOKEN != '' && secrets.QISKIT_IBM_INSTANCE != '' && vars.QISKIT_IBM_BACKEND != '' }}
     runs-on: ubuntu-latest
     continue-on-error: true
     env:
@@ -21,8 +20,19 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: "1.11"
+      - name: Check IBM runtime configuration
+        id: config
+        shell: bash
+        run: |
+          if [ -z "${QISKIT_IBM_TOKEN}" ] || [ -z "${QISKIT_IBM_INSTANCE}" ] || [ -z "${QISKIT_IBM_BACKEND}" ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
       - uses: julia-actions/julia-buildpkg@v1
+        if: steps.config.outputs.ready == 'true'
       - name: Run QAOA smoke test on IBM hardware
+        if: steps.config.outputs.ready == 'true'
         run: |
           julia --project=. -e '
           using JuMP
@@ -40,3 +50,6 @@ jobs:
           optimize!(model)
           @assert result_count(model) >= 1
           '
+      - name: Skip when IBM configuration is unavailable
+        if: steps.config.outputs.ready != 'true'
+        run: echo "Skipping IBM hardware smoke test because credentials or backend configuration are not set."

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,13 +1,12 @@
-channels = ["anaconda", "conda-forge"]
+channels = ["conda-forge"]
 
 [deps]
-python = ">=3.7,<=3.11"
+python = ">=3.11,<3.12"
 
 [pip.deps]
-qiskit              = "==1.1.0"
-qiskit-optimization = "==0.6.1"
-qiskit-ibm-runtime = "==0.23.0"
-qiskit-algorithms   = "==0.3.0"
-qiskit-aer          = "==0.14.1"
-scipy               = "==1.13.0"
-numpy               = "==1.26.0"
+numpy               = "~=2.2.0"
+qiskit              = "~=2.3.0"
+qiskit-aer          = "~=0.17.0"
+qiskit-ibm-runtime  = "~=0.46.0"
+qiskit-optimization = "~=0.7.0"
+scipy               = "~=1.15.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QiskitOpt"
 uuid = "81b20daf-e62b-4502-a0d1-aa084de80e33"
-authors = ["pedromxavier <pedroxavier@psr-inc.com>", "pedroripper <pedroripper@psr-inc.com>"]
+authors = ["pedromxavier <pedroxavier@psr-inc.com>", "pedroripper <pedroripper@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
 version = "0.4.0"
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,13 @@
 name = "QiskitOpt"
 uuid = "81b20daf-e62b-4502-a0d1-aa084de80e33"
 authors = ["pedromxavier <pedroxavier@psr-inc.com>", "pedroripper <pedroripper@psr-inc.com>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 QUBO = "ce8c2e91-a970-4681-856b-16178c24a30c"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-PythonCall = "0.9.20"
-julia = "1.9"
-QUBO = "0.3.0"
+PythonCall = "0.9"
+julia = "1.10"
+QUBO = "0.4"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ julia> Pkg.develop(url="https://github.com/JuliaQUBO/QiskitOpt.jl")
 ```
 
 ## Local Quickstart
-`QiskitOpt.jl` now defaults to credential-free local execution. If you do not pick a real IBM backend explicitly, both `QAOA.Optimizer` and `VQE.Optimizer` run against a fake backend through Qiskit Runtime's local testing mode.
+`QiskitOpt.jl` now defaults to credential-free local execution. If you do not pick a real IBM backend explicitly, both `QAOA.Optimizer` and `VQE.Optimizer` run locally with Aer using the matrix-product-state simulator.
 
 ```julia
 using JuMP
@@ -43,7 +43,7 @@ Q = [
 @variable(model, x[1:3], Bin)
 @objective(model, Min, x' * Q * x)
 
-# No IBM token is required for local fake-backend execution.
+# No IBM token is required for default local Aer execution.
 optimize!(model)
 
 for i = 1:result_count(model)
@@ -73,7 +73,7 @@ set_attribute(model, QAOA.NumberOfLayers(), 5)
 ## Choosing a Local Backend
 
 ```julia
-# Use a different fake backend for local testing
+# Use a fake IBM backend for local testing
 set_attribute(
     model,
     VQE.IBMFakeBackend(),
@@ -94,7 +94,7 @@ Execution mode is selected from the backend attributes:
 
 | Configuration | Behavior |
 | --- | --- |
-| No `IBMBackend()` | Use `IBMFakeBackend()` locally. No IBM credentials or runtime service are required. |
+| No `IBMBackend()` | Use the configured local backend, which defaults to `AerSimulator(method="matrix_product_state")`. No IBM credentials or runtime service are required. |
 | `IBMBackend()` and `IsLocal() == true` | Fetch the named IBM backend configuration, then run locally with `AerSimulator.from_backend(...)`. IBM credentials are required for backend lookup. |
 | `IBMBackend()` and `IsLocal() == false` | Submit `EstimatorV2` and `SamplerV2` jobs to the selected IBM backend. IBM credentials are required. |
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ List of fake backends available: [Qiskit Documentation](https://docs.quantum.ibm
 ## IBM Quantum Platform
 To run on a real IBM backend, set `IBMBackend()` explicitly and authenticate with the current IBM Quantum Platform flow. The package does not call `save_account()` on import and does not write credentials to disk for you.
 
+Execution mode is selected from the backend attributes:
+
+| Configuration | Behavior |
+| --- | --- |
+| No `IBMBackend()` | Use `IBMFakeBackend()` locally. No IBM credentials or runtime service are required. |
+| `IBMBackend()` and `IsLocal() == true` | Fetch the named IBM backend configuration, then run locally with `AerSimulator.from_backend(...)`. IBM credentials are required for backend lookup. |
+| `IBMBackend()` and `IsLocal() == false` | Submit `EstimatorV2` and `SamplerV2` jobs to the selected IBM backend. IBM credentials are required. |
+
 The supported environment variables are:
 
 - `QISKIT_IBM_TOKEN`
@@ -99,6 +107,8 @@ The supported environment variables are:
 Legacy `IBMQ_API_TOKEN` and `IBMQ_INSTANCE` names are still accepted as fallbacks, but they are no longer the documented primary path.
 
 If you do not call `set_attribute(model, QAOA.Channel(), ...)` or `set_attribute(model, VQE.Channel(), ...)`, the package will read `QISKIT_IBM_CHANNEL` and otherwise fall back to `ibm_quantum_platform`.
+
+IBM documents the current account construction in the [`QiskitRuntimeService` API reference](https://quantum.cloud.ibm.com/docs/en/api/qiskit-ibm-runtime/qiskit-runtime-service). The IBM docs describe the API key as the minimum required authentication input for non-local channels, but they recommend providing the instance or CRN as well to avoid account discovery and ambiguity. The local emulation behavior follows IBM's [Qiskit Runtime local testing mode](https://quantum.cloud.ibm.com/docs/en/guides/local-testing-mode).
 
 Example setup:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # QiskitOpt.jl
 [![DOI](https://zenodo.org/badge/587349377.svg)](https://zenodo.org/badge/latestdoi/587349377)
-[![QUBODRIVERS](https://img.shields.io/badge/Powered%20by-QUBODrivers.jl-%20%234063d8)](https://github.com/psrenergy/QUBODrivers.jl)
+[![QUBODRIVERS](https://img.shields.io/badge/Powered%20by-QUBODrivers.jl-%20%234063d8)](https://github.com/JuliaQUBO/QUBODrivers.jl)
 
 IBM Qiskit Optimization Wrapper for JuMP
 
@@ -11,7 +11,9 @@ julia> import Pkg
 julia> Pkg.add("QiskitOpt")
 ```
 
-## Basic Usage
+## Local Quickstart
+`QiskitOpt.jl` now defaults to credential-free local execution. If you do not pick a real IBM backend explicitly, both `QAOA.Optimizer` and `VQE.Optimizer` run against a fake backend through Qiskit Runtime's local testing mode.
+
 ```julia
 using JuMP
 using QiskitOpt
@@ -31,6 +33,7 @@ Q = [
 @variable(model, x[1:3], Bin)
 @objective(model, Min, x' * Q * x)
 
+# No IBM token is required for local fake-backend execution.
 optimize!(model)
 
 for i = 1:result_count(model)
@@ -45,51 +48,83 @@ end
 
 ```julia
 # Number of shots
-MOI.set(model, VQE.NumberOfReads(), 1000) # or QAOA.NumberOfReads 
+set_attribute(model, VQE.NumberOfReads(), 1000) # or QAOA.NumberOfReads
 
 # Maximum optimizer iterations
-MOI.set(model, VQE.MaximumIterations(), 100) # or QAOA.MaximumIterations 
+set_attribute(model, VQE.MaximumIterations(), 100) # or QAOA.MaximumIterations
 
 # Ansatz
-MOI.set(model, VQE.Ansatz(), QiskitOpt.qiskit.circuit.library.EfficientSU2) # or QAOA.Ansatz 
+set_attribute(model, VQE.Ansatz(), QiskitOpt.qiskit.circuit.library.EfficientSU2)
 
 # Number of QAOA ansatz repetitions (for QAOA only)
-MOI.set(model, QAOA.NumberOfLayers(), 5)  
+set_attribute(model, QAOA.NumberOfLayers(), 5)
 ```
 
-## Changing the backend and instance
-
+## Choosing a Local Backend
 
 ```julia
-MOI.set(model, VQE.IBMBackend(), "ibm_osaka") # or QAOA.IBMBackend
-MOI.set(model, VQE.Instance(), "my/instance") # or QAOA.Instance
+# Use a different fake backend for local testing
+set_attribute(
+    model,
+    VQE.IBMFakeBackend(),
+    QiskitOpt.qiskit_ibm_runtime.fake_provider.FakeManilaV2,
+)
 
-# Using a fake backend
-MOI.set(model, VQE.IBMFakeBackend(), QiskitOpt.qiskit_ibm_runtime.fake_provider.FakeAlgiers) # or QAOA.IBMFakeBackend
-
+# Or emulate the noise model of a named IBM backend locally through Aer
+set_attribute(model, VQE.IBMBackend(), "ibm_fez")
+set_attribute(model, VQE.IsLocal(), true)
 ```
 
 List of fake backends available: [Qiskit Documentation](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/fake_provider#fake-backends)
 
-## API Token
-To access IBM's Quantum Computers, it is necessary to create an account at [IBM Q](https://quantum-computing.ibm.com/) to obtain an API Token and run the following python code:
+## IBM Quantum Platform
+To run on a real IBM backend, set `IBMBackend()` explicitly and authenticate with the current IBM Quantum Platform flow. The package does not call `save_account()` on import and does not write credentials to disk for you.
+
+The supported environment variables are:
+
+- `QISKIT_IBM_TOKEN`
+- `QISKIT_IBM_INSTANCE`
+- `QISKIT_IBM_CHANNEL` (optional, defaults to `ibm_quantum_platform`)
+
+Legacy `IBMQ_API_TOKEN` and `IBMQ_INSTANCE` names are still accepted as fallbacks, but they are no longer the documented primary path.
+
+If you do not call `set_attribute(model, QAOA.Channel(), ...)` or `set_attribute(model, VQE.Channel(), ...)`, the package will read `QISKIT_IBM_CHANNEL` and otherwise fall back to `ibm_quantum_platform`.
+
+Example setup:
+
+```shell
+export QISKIT_IBM_TOKEN=YOUR_API_KEY
+export QISKIT_IBM_INSTANCE=YOUR_IBM_CLOUD_CRN
+export QISKIT_IBM_CHANNEL=ibm_quantum_platform
+```
+
+```julia
+using JuMP
+using QiskitOpt
+
+model = Model(QiskitOpt.QAOA.Optimizer)
+
+@variable(model, x[1:3], Bin)
+@objective(model, Min, x[1] + x[2] + x[3] - 2x[1]x[2] - 2x[2]x[3])
+
+set_attribute(model, QiskitOpt.QAOA.IBMBackend(), "ibm_fez")
+
+optimize!(model)
+```
+
+If you prefer a saved Qiskit account, the current Python-side command is:
 
 ```python
 from qiskit_ibm_runtime import QiskitRuntimeService
 
-QiskitRuntimeService.save_account(channel='ibm_quantum', token="YOUR_TOKEN_HERE")
-```
-
-Another option is to set the `IBMQ_API_TOKEN` environment variable before loading `QiskitOpt.jl`:
-```shell
-$ export IBMQ_API_TOKEN=YOUR_TOKEN_HERE
-
-$ julia
-
-julia> using QiskitOpt
+QiskitRuntimeService.save_account(
+    channel="ibm_quantum_platform",
+    token="YOUR_API_KEY",
+    instance="YOUR_IBM_CLOUD_CRN",
+    set_as_default=True,
+)
 ```
 
 **Disclaimer:** _The IBM Qiskit Optimization Wrapper for Julia is not officially supported by IBM. If you are a commercial customer interested in official support for Julia from IBM, let them know!_
 
-**Note**: _If you are using [QiskitOpt.jl](https://github.com/psrenergy/QiskitOpt.jl) in your project, we recommend you to include the `.CondaPkg` entry in your `.gitignore` file. The PythonCall module will place a lot of files in this folder when building its Python environment._
-
+**Note**: _If you are using [QiskitOpt.jl](https://github.com/JuliaQUBO/QiskitOpt.jl) in your project, we recommend you to include the `.CondaPkg` entry in your `.gitignore` file. The PythonCall module will place a lot of files in this folder when building its Python environment._

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ julia> Pkg.add("QiskitOpt")
 
 `Pkg.add("QiskitOpt")` installs the registered package from Julia's General registry. Use `QiskitOpt` as the package name; the `.jl` suffix only appears in the GitHub repository name.
 
+`QiskitOpt` provides MOI-compatible optimizers and does not depend on JuMP directly. Install JuMP separately if you want to run the examples below:
+
+```julia
+julia> Pkg.add("JuMP")
+```
+
 If you want a development checkout from source instead of the registered package, use:
 
 ```julia
@@ -109,6 +115,15 @@ Legacy `IBMQ_API_TOKEN` and `IBMQ_INSTANCE` names are still accepted as fallback
 If you do not call `set_attribute(model, QAOA.Channel(), ...)` or `set_attribute(model, VQE.Channel(), ...)`, the package will read `QISKIT_IBM_CHANNEL` and otherwise fall back to `ibm_quantum_platform`.
 
 IBM documents the current account construction in the [`QiskitRuntimeService` API reference](https://quantum.cloud.ibm.com/docs/en/api/qiskit-ibm-runtime/qiskit-runtime-service). The IBM docs describe the API key as the minimum required authentication input for non-local channels, but they recommend providing the instance or CRN as well to avoid account discovery and ambiguity. The local emulation behavior follows IBM's [Qiskit Runtime local testing mode](https://quantum.cloud.ibm.com/docs/en/guides/local-testing-mode).
+
+For the non-blocking GitHub Actions hardware smoke workflow, configure these repository settings under `Settings` -> `Secrets and variables` -> `Actions`:
+
+- Secret `QISKIT_IBM_TOKEN`: IBM Quantum Platform API key.
+- Secret `QISKIT_IBM_INSTANCE`: IBM Cloud CRN or runtime instance.
+- Variable `QISKIT_IBM_BACKEND`: backend name, for example `ibm_fez`.
+- Variable `QISKIT_IBM_CHANNEL`: optional, defaults to `ibm_quantum_platform` when omitted.
+
+After those values are set, run the `IBM Hardware Smoke` workflow manually from the `Actions` tab, or let the scheduled monthly run exercise it.
 
 Example setup:
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ julia> import Pkg
 julia> Pkg.add("QiskitOpt")
 ```
 
+`Pkg.add("QiskitOpt")` installs the registered package from Julia's General registry. Use `QiskitOpt` as the package name; the `.jl` suffix only appears in the GitHub repository name.
+
+If you want a development checkout from source instead of the registered package, use:
+
+```julia
+julia> import Pkg
+
+julia> Pkg.develop(url="https://github.com/JuliaQUBO/QiskitOpt.jl")
+```
+
 ## Local Quickstart
 `QiskitOpt.jl` now defaults to credential-free local execution. If you do not pick a real IBM backend explicitly, both `QAOA.Optimizer` and `VQE.Optimizer` run against a fake backend through Qiskit Runtime's local testing mode.
 

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -3,6 +3,7 @@ module QAOA
 using PythonCall: pyconvert, pylist, pydict, pyint, @pyexec
 using ..QiskitOpt:
     backend_name,
+    default_local_backend,
     empty_metadata,
     qiskit,
     qiskit_ibm_runtime,
@@ -27,7 +28,7 @@ QUBODrivers.@setup Optimizer begin
         NumberOfReads["num_reads"]::Integer        = 100
         NumberOfLayers["num_layers"]::Integer      = 1
         InitialParameters["initial_parameters"]::Union{Vector{Float64}, Nothing} = nothing 
-        IBMFakeBackend["ibm_fake_backend"]         = qiskit_ibm_runtime.fake_provider.FakeManilaV2
+        IBMFakeBackend["ibm_fake_backend"]         = default_local_backend
         IBMBackend["ibm_backend"]::Union{String, Nothing} = nothing
         IsLocal["is_local"]::Bool                  = false
         Channel["channel"]::Union{String, Nothing} = nothing

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -1,13 +1,17 @@
 module QAOA
 
-using LinearAlgebra
-using PythonCall: pyconvert, pylist, pydict, pyint, pytuple, pybool, @pyexec
+using PythonCall: pyconvert, pylist, pydict, pyint, @pyexec
 using ..QiskitOpt:
+    backend_name,
+    empty_metadata,
     qiskit,
     qiskit_ibm_runtime,
-    qiskit_algorithms,
     qiskit_aer,
     quadratic_program,
+    runtime_channel,
+    runtime_instance,
+    runtime_service,
+    sample_bits,
     scipy,
     numpy
 
@@ -17,50 +21,36 @@ Sample = QUBODrivers.Sample
 SampleSet = QUBODrivers.SampleSet
 
 QUBODrivers.@setup Optimizer begin
-    name    = "QAOA @ IBMQ"
+    name    = "QAOA @ IBM Quantum"
     attributes = begin
         MaximumIterations["max_iter"]::Integer     = 15
         NumberOfReads["num_reads"]::Integer        = 100
-        NumberOfLayers["num_layers"]::Integer   = 1
+        NumberOfLayers["num_layers"]::Integer      = 1
         InitialParameters["initial_parameters"]::Union{Vector{Float64}, Nothing} = nothing 
-        IBMFakeBackend["ibm_fake_backend"]   = qiskit_ibm_runtime.fake_provider.FakeAlgiers
-        IBMBackend["ibm_backend"]::Union{String, Nothing}  = nothing
-        IsLocal["is_local"]::Bool          = false
-        Entanglement["entanglement"]::String       = "linear"
-        Channel["channel"]::String                 = "ibm_quantum"
-        Instance["instance"]::String               = "ibm-q/open/main"
+        IBMFakeBackend["ibm_fake_backend"]         = qiskit_ibm_runtime.fake_provider.FakeManilaV2
+        IBMBackend["ibm_backend"]::Union{String, Nothing} = nothing
+        IsLocal["is_local"]::Bool                  = false
+        Channel["channel"]::Union{String, Nothing} = nothing
+        Instance["instance"]::Union{String, Nothing} = nothing
     end
 end
 
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
-    # -*- Retrieve Attributes - *-
-    n, L, Q, α, β = QUBOTools.qubo(sampler, :dense)
-    ibm_backend = MOI.get(sampler, QAOA.IBMBackend())
+    # Retrieve Model
+    _, L, Q, α, β = QUBOTools.qubo(sampler, :dense)
+    sense = MOI.get(sampler, MOI.ObjectiveSense())
 
     # Results vector
     samples = QUBOTools.Sample{T,Int}[]
 
-    # Extra Information 
-    metadata = Dict{String,Any}(
-        "origin" => "IBMQ QAOA @ $(ibm_backend)",
-        "time"   => Dict{String,Any}(),
-        "evals"  => Vector{Float64}(),
-    )
-
-    retrieve(sampler) do result, sample_results
-        if MOI.get(sampler, MOI.ObjectiveSense()) == MOI.MAX_SENSE
-            α = -α
-        end
-
+    metadata = retrieve(sampler) do _, sample_results
         for key in sample_results.keys()
-            state = reverse(parse.(Int,split(pyconvert.(String, key),"")))
+            state = sample_bits(key)
+            objective_value = QUBOTools.value(state, L, Q, α, β)
             sample = QUBOTools.Sample{T,Int}(
-            # state:
-            state,
-            # energy:
-            α * (state'* (Q+Diagonal(L)) * state + β),
-            # reads:
-            pyconvert(Int, sample_results[key])
+                state,
+                sense == MOI.MAX_SENSE ? -objective_value : objective_value,
+                pyconvert(Int, sample_results[key]),
             )   
             push!(samples, sample)
         end
@@ -75,16 +65,16 @@ function retrieve(
     callback::Function,
     sampler::Optimizer{T},
 ) where {T}
-    # -*- Retrieve Attributes -*- #
+    # Retrieve Attributes
     max_iter        = MOI.get(sampler, QAOA.MaximumIterations())
-    num_reads        = MOI.get(sampler, QAOA.NumberOfReads())
+    num_reads       = MOI.get(sampler, QAOA.NumberOfReads())
     num_layers      = MOI.get(sampler, QAOA.NumberOfLayers())
     ibm_backend     = MOI.get(sampler, QAOA.IBMBackend())
     ibm_fake_backend = MOI.get(sampler, QAOA.IBMFakeBackend())
-    channel         = MOI.get(sampler, QAOA.Channel())
-    instance        = MOI.get(sampler, QAOA.Instance())
+    channel         = runtime_channel(MOI.get(sampler, QAOA.Channel()))
+    instance        = runtime_instance(MOI.get(sampler, QAOA.Instance()))
     initial_parameters   = MOI.get(sampler, QAOA.InitialParameters())
-    is_local    = MOI.get(sampler, QAOA.IsLocal())
+    is_local         = MOI.get(sampler, QAOA.IsLocal())
 
     @pyexec """
     def cost_function(params, ansatz, hamiltonian, estimator):
@@ -94,87 +84,63 @@ function retrieve(
         return energy
     """ => cost_function
 
-    service = qiskit_ibm_runtime.QiskitRuntimeService(
-        channel  = channel,
-        instance = instance,
-    )   
-
-    backend = if !isnothing(ibm_backend)
-        _backend = service.get_backend(ibm_backend)
-        if is_local && ibm_backend != "ibmq_qasm_simulator"
-            qiskit_aer.AerSimulator.from_backend(_backend)
-        else
-            _backend
-        end
+    backend, execution_mode = if isnothing(ibm_backend)
+        (ibm_fake_backend(), "local")
     else
-        _backend = ibm_fake_backend()
-        is_local = true
-        ibm_backend = _backend.backend_name
-        _backend
+        remote_backend = runtime_service(channel=channel, instance=instance).backend(ibm_backend)
+        if is_local
+            (qiskit_aer.AerSimulator.from_backend(remote_backend), "local")
+        else
+            (remote_backend, "cloud")
+        end
     end
-
-    if is_local && ibm_backend != "ibmq_qasm_simulator"
-        backend = qiskit_aer.AerSimulator.from_backend(backend)
-    end
+    backend_label = backend_name(backend)
 
     ising_qp = quadratic_program(sampler)
     ising_hamiltonian = ising_qp[0]
     ansatz = qiskit.circuit.library.QAOAAnsatz(
         ising_hamiltonian,
-        reps = num_layers
+        reps=num_layers,
     )
 
-    # pass manager for the quantum circuit (optimize the circuit for the target device)
     pass_manager = qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager(
-        target = backend.target,
-        optimization_level = 3
+        backend=backend,
+        optimization_level=3,
     )
     
-    
-    # Ansatz and Hamiltonian to ISA (Instruction Set Architecture)
     ansatz_isa = pass_manager.run(ansatz)
-    ising_hamiltonian = ising_hamiltonian.apply_layout(layout = ansatz_isa.layout)
+    ising_hamiltonian = ising_hamiltonian.apply_layout(layout=ansatz_isa.layout)
 
 
     if isnothing(initial_parameters)
-        initial_parameters = numpy.empty([ansatz_isa.num_parameters])
-        for i in 1:pyconvert(Int, ansatz_isa.num_parameters)
-            initial_parameters[i-1] = numpy.random.rand()
-        end
-    end
-
-    estimator = if is_local || ibm_backend == "ibmq_qasm_simulator"
-        qiskit_ibm_runtime.EstimatorV2(backend = backend)
+        initial_parameters = numpy.zeros(pyint(pyconvert(Int, ansatz_isa.num_parameters)))
     else
-        session = qiskit_ibm_runtime.Session(service=service, backend=backend)
-        qiskit_ibm_runtime.EstimatorV2(session=session)
-    end
-    if !is_local
-        estimator.options.default_shots = num_reads
+        initial_parameters = numpy.array(initial_parameters)
     end
 
-    println("Running QAOA on $(ibm_backend)...")
+    estimator = qiskit_ibm_runtime.EstimatorV2(mode=backend)
+    estimator.options.default_shots = num_reads
     scipy_options = pydict()
     scipy_options["maxiter"] = max_iter
     result = scipy.optimize.minimize(
         cost_function,
         initial_parameters,
-        args = (ansatz_isa, ising_hamiltonian, estimator),
-        method = "cobyla",
-        options = scipy_options
+        args=(ansatz_isa, ising_hamiltonian, estimator),
+        method="cobyla",
+        options=scipy_options,
     )
 
     qc = ansatz.assign_parameters(result.x)
     qc.measure_all()
     optimized_qc = pass_manager.run(qc)
 
-    qiskit_sampler = qiskit.primitives.StatevectorSampler(default_shots = pyint(num_reads))
-    sampling_result = qiskit_sampler.run(pylist([optimized_qc])).result()[0]
+    qiskit_sampler = qiskit_ibm_runtime.SamplerV2(mode=backend)
+    sampling_result = qiskit_sampler.run(pylist([optimized_qc]), shots=pyint(num_reads)).result()[0]
     samples = sampling_result.data.meas.get_counts()
 
     callback(result, samples)
 
-    return nothing
+    return empty_metadata("QAOA", backend_label, execution_mode)
 end
 
 end # module QAOA

--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -111,6 +111,10 @@ function runtime_service(;
     )
 end
 
+function default_local_backend()
+    return qiskit_aer.AerSimulator(method="matrix_product_state")
+end
+
 function backend_name(backend)
     try
         return PythonCall.pyconvert(String, backend.name)

--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -4,32 +4,134 @@ using PythonCall
 using QUBO
 MOI = QUBODrivers.MOI
 
+const DEFAULT_RUNTIME_CHANNEL = "ibm_quantum_platform"
+
 # :: Python Qiskit Modules ::
 const qiskit              = PythonCall.pynew()
 const qiskit_optimization = PythonCall.pynew()
 const qiskit_ibm_runtime  = PythonCall.pynew()
-const qiskit_algorithms   = PythonCall.pynew()
 const qiskit_aer          = PythonCall.pynew()  
 const scipy               = PythonCall.pynew()
 const numpy               = PythonCall.pynew()
+const _runtime_service_builder = Ref{Function}()
 
 function __init__()
     # Load Python Packages
     PythonCall.pycopy!(qiskit, pyimport("qiskit"))
     PythonCall.pycopy!(qiskit_optimization, pyimport("qiskit_optimization"))
     PythonCall.pycopy!(qiskit_ibm_runtime, pyimport("qiskit_ibm_runtime"))
-    PythonCall.pycopy!(qiskit_algorithms, pyimport("qiskit_algorithms"))
     PythonCall.pycopy!(qiskit_aer, pyimport("qiskit_aer"))
     PythonCall.pycopy!(scipy, pyimport("scipy"))
     PythonCall.pycopy!(numpy, pyimport("numpy"))
+    _runtime_service_builder[] = default_runtime_service
+end
 
-    # IBMQ Credentials
-    IBMQ_API_TOKEN = get(ENV, "IBMQ_API_TOKEN", nothing)
-    IBMQ_INSTANCE = get(ENV, "IBMQ_INSTANCE", "ibm-q/open/main")
-
-    if !isnothing(IBMQ_API_TOKEN)
-        qiskit_ibm_runtime.QiskitRuntimeService.save_account(channel=pystr("ibm_quantum"), instance = pystr(IBMQ_INSTANCE), token=pystr(IBMQ_API_TOKEN))
+function nonempty_or_nothing(value)
+    if isnothing(value)
+        return nothing
     end
+
+    text = strip(String(value))
+    return isempty(text) ? nothing : text
+end
+
+function runtime_channel(channel::Union{Nothing,AbstractString} = nothing)
+    provided = nonempty_or_nothing(channel)
+    if !isnothing(provided)
+        return provided == "ibm_quantum" ? DEFAULT_RUNTIME_CHANNEL : provided
+    end
+
+    env_channel = nonempty_or_nothing(get(ENV, "QISKIT_IBM_CHANNEL", nothing))
+    if isnothing(env_channel) || env_channel == "ibm_quantum"
+        return DEFAULT_RUNTIME_CHANNEL
+    end
+
+    return env_channel
+end
+
+function runtime_token()
+    for name in ("QISKIT_IBM_TOKEN", "IBMQ_API_TOKEN")
+        token = nonempty_or_nothing(get(ENV, name, nothing))
+        !isnothing(token) && return token
+    end
+
+    return nothing
+end
+
+function runtime_instance(instance::Union{Nothing,AbstractString} = nothing)
+    provided = nonempty_or_nothing(instance)
+    !isnothing(provided) && return provided
+
+    for name in ("QISKIT_IBM_INSTANCE", "IBMQ_INSTANCE")
+        resolved = nonempty_or_nothing(get(ENV, name, nothing))
+        !isnothing(resolved) && return resolved
+    end
+
+    return nothing
+end
+
+function default_runtime_service(;
+    channel::Union{Nothing,AbstractString} = nothing,
+    token::Union{Nothing,AbstractString} = nothing,
+    instance::Union{Nothing,AbstractString} = nothing,
+)
+    resolved_channel = runtime_channel(channel)
+    resolved_token = nonempty_or_nothing(token)
+    resolved_instance = runtime_instance(instance)
+
+    if isnothing(resolved_token) && isnothing(resolved_instance)
+        return qiskit_ibm_runtime.QiskitRuntimeService(channel=resolved_channel)
+    elseif isnothing(resolved_token)
+        return qiskit_ibm_runtime.QiskitRuntimeService(
+            channel=resolved_channel,
+            instance=resolved_instance,
+        )
+    elseif isnothing(resolved_instance)
+        return qiskit_ibm_runtime.QiskitRuntimeService(
+            channel=resolved_channel,
+            token=resolved_token,
+        )
+    end
+
+    return qiskit_ibm_runtime.QiskitRuntimeService(
+        channel=resolved_channel,
+        token=resolved_token,
+        instance=resolved_instance,
+    )
+end
+
+function runtime_service(;
+    channel::Union{Nothing,AbstractString} = nothing,
+    instance::Union{Nothing,AbstractString} = nothing,
+)
+    return _runtime_service_builder[](
+        channel=runtime_channel(channel),
+        token=runtime_token(),
+        instance=runtime_instance(instance),
+    )
+end
+
+function backend_name(backend)
+    try
+        return PythonCall.pyconvert(String, backend.name)
+    catch
+        return PythonCall.pyconvert(String, backend.backend_name)
+    end
+end
+
+function sample_bits(key)
+    bitstring = replace(PythonCall.pyconvert(String, key), " " => "")
+    return reverse(Int[(digit == '1') for digit in bitstring])
+end
+
+function empty_metadata(algorithm::AbstractString, backend::AbstractString, execution_mode::AbstractString)
+    return Dict{String,Any}(
+        "origin" => "$(algorithm) @ $(backend)",
+        "backend" => backend,
+        "execution_mode" => execution_mode,
+        "time" => Dict{String,Any}(),
+        "evals" => Float64[],
+    )
 end
 
 function quadratic_program(sampler::QUBODrivers.AbstractSampler{T}) where {T}
@@ -39,19 +141,20 @@ function quadratic_program(sampler::QUBODrivers.AbstractSampler{T}) where {T}
     # Build Qiskit Model
     linear    = PythonCall.pydict()
     quadratic = PythonCall.pydict()
+    variable_names = string.(1:n)
 
     sense = MOI.get(sampler, MOI.ObjectiveSense())
 
     for i in 1:n
-        linear[string(i)] = L[i] * (sense == MOI.MIN_SENSE ? 1 : -1)
+        linear[variable_names[i]] = L[i] * (sense == MOI.MIN_SENSE ? 1 : -1)
     end
     for i in 1:n, j in 1:n
-        quadratic[string(i), string(j)] = Q[i,j] * (sense == MOI.MIN_SENSE ? 1 : -1)
+        quadratic[variable_names[i], variable_names[j]] = Q[i,j] * (sense == MOI.MIN_SENSE ? 1 : -1)
     end
 
     qp = qiskit_optimization.QuadraticProgram()
 
-    for v in string.(QUBOTools.indices(sampler))
+    for v in variable_names
         qp.binary_var(v)
     end
 

--- a/src/VQE.jl
+++ b/src/VQE.jl
@@ -1,13 +1,17 @@
 module VQE
 
-using LinearAlgebra
-using PythonCall: pyconvert, pylist, pydict, pyint, pytuple, @pyexec
+using PythonCall: pyconvert, pylist, pydict, pyint, @pyexec
 using ..QiskitOpt:
+    backend_name,
+    empty_metadata,
     qiskit,
     qiskit_ibm_runtime,
-    qiskit_algorithms,
     qiskit_aer,
     quadratic_program,
+    runtime_channel,
+    runtime_instance,
+    runtime_service,
+    sample_bits,
     scipy,
     numpy
 
@@ -17,50 +21,36 @@ Sample = QUBODrivers.Sample
 SampleSet = QUBODrivers.SampleSet
 
 QUBODrivers.@setup Optimizer begin
-    name    = "VQE @ IBMQ"
+    name    = "VQE @ IBM Quantum"
     attributes = begin
         MaximumIterations["max_iter"]::Integer     = 15
-        NumberOfReads["num_reads"]::Integer   = 100
+        NumberOfReads["num_reads"]::Integer        = 100
         InitialParameters["initial_parameters"]::Union{Vector{Float64}, Nothing} = nothing 
-        IBMFakeBackend["ibm_fake_backend"]         = qiskit_ibm_runtime.fake_provider.FakeAlgiers
-        IBMBackend["ibm_backend"]::Union{String, Nothing}          = nothing
-        IsLocal["is_local"]::Bool          = false
-        Channel["channel"]::String                 = "ibm_quantum"
-        Instance["instance"]::String               = "ibm-q/open/main"
+        IBMFakeBackend["ibm_fake_backend"]         = qiskit_ibm_runtime.fake_provider.FakeManilaV2
+        IBMBackend["ibm_backend"]::Union{String, Nothing} = nothing
+        IsLocal["is_local"]::Bool                  = false
+        Channel["channel"]::Union{String, Nothing} = nothing
+        Instance["instance"]::Union{String, Nothing} = nothing
         Ansatz["ansatz"]                           = qiskit.circuit.library.EfficientSU2
     end
 end
 
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     # Retrieve Model
-    n, L, Q, α, β = QUBOTools.qubo(sampler, :dense)
-    ibm_backend = MOI.get(sampler, VQE.IBMBackend())
-
+    _, L, Q, α, β = QUBOTools.qubo(sampler, :dense)
+    sense = MOI.get(sampler, MOI.ObjectiveSense())
 
     # Results vector
     samples = QUBOTools.Sample{T,Int}[]
 
-    # Extra Information 
-    metadata = Dict{String,Any}(
-        "origin" => "IBMQ VQE @ $(ibm_backend)",
-        "time"   => Dict{String,Any}(),
-        "evals"  => Vector{Float64}(),
-    )
-
-    retrieve(sampler) do result, sample_results
-        if MOI.get(sampler, MOI.ObjectiveSense()) == MOI.MAX_SENSE
-            α = -α
-        end
-
+    metadata = retrieve(sampler) do _, sample_results
         for key in sample_results.keys()
-            state = reverse(parse.(Int,split(pyconvert.(String, key),"")))
+            state = sample_bits(key)
+            objective_value = QUBOTools.value(state, L, Q, α, β)
             sample = QUBOTools.Sample{T,Int}(
-            # state:
-            state,
-            # energy:
-            QUBOTools.value(state, L, Q, α, β),
-            # reads:
-            pyconvert(Int, sample_results[key])
+                state,
+                sense == MOI.MAX_SENSE ? -objective_value : objective_value,
+                pyconvert(Int, sample_results[key]),
             )   
             push!(samples, sample)
         end
@@ -77,15 +67,14 @@ function retrieve(
 ) where {T}
     # Retrieve Attributes
     max_iter        = MOI.get(sampler, VQE.MaximumIterations())
-    num_reads        = MOI.get(sampler, VQE.NumberOfReads())
-    num_qubits      = MOI.get(sampler, MOI.NumberOfVariables())
+    num_reads       = MOI.get(sampler, VQE.NumberOfReads())
     ibm_backend     = MOI.get(sampler, VQE.IBMBackend())
     ibm_fake_backend = MOI.get(sampler, VQE.IBMFakeBackend())
     ansatz_instance = MOI.get(sampler, VQE.Ansatz())
-    channel         = MOI.get(sampler, VQE.Channel())
-    instance        = MOI.get(sampler, VQE.Instance())
+    channel         = runtime_channel(MOI.get(sampler, VQE.Channel()))
+    instance        = runtime_instance(MOI.get(sampler, VQE.Instance()))
     initial_parameters   = MOI.get(sampler, VQE.InitialParameters())
-    is_local    = MOI.get(sampler, VQE.IsLocal())
+    is_local         = MOI.get(sampler, VQE.IsLocal())
 
     @pyexec """
     def cost_function(params, ansatz, hamiltonian, estimator):
@@ -95,80 +84,61 @@ function retrieve(
         return energy
     """ => cost_function
 
-    service = qiskit_ibm_runtime.QiskitRuntimeService(
-        channel  = channel,
-        instance = instance,
-    )   
-
-    backend = if !isnothing(ibm_backend)
-        _backend = service.get_backend(ibm_backend)
-        if is_local && ibm_backend != "ibmq_qasm_simulator"
-            qiskit_aer.AerSimulator.from_backend(_backend)
-        else
-            _backend
-        end
+    backend, execution_mode = if isnothing(ibm_backend)
+        (ibm_fake_backend(), "local")
     else
-        _backend = ibm_fake_backend()
-        is_local = true
-        ibm_backend = _backend.backend_name
-        _backend
+        remote_backend = runtime_service(channel=channel, instance=instance).backend(ibm_backend)
+        if is_local
+            (qiskit_aer.AerSimulator.from_backend(remote_backend), "local")
+        else
+            (remote_backend, "cloud")
+        end
     end
+    backend_label = backend_name(backend)
 
     ising_qp = quadratic_program(sampler)
     ising_hamiltonian = ising_qp[0]
-    ansatz = ansatz_instance(num_qubits = num_qubits)
+    num_qubits = pyconvert(Int, ising_hamiltonian.num_qubits)
+    ansatz = ansatz_instance(num_qubits=num_qubits)
 
-    # pass manager for the quantum circuit (optimize the circuit for the target device)
     pass_manager = qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager(
-        target = backend.target,
-        optimization_level = 3
-        )
+        backend=backend,
+        optimization_level=3,
+    )
     
-    
-    # Ansatz and Hamiltonian to ISA (Instruction Set Architecture)
     ansatz_isa = pass_manager.run(ansatz)
-    ising_hamiltonian = ising_hamiltonian.apply_layout(layout = ansatz_isa.layout)
+    ising_hamiltonian = ising_hamiltonian.apply_layout(layout=ansatz_isa.layout)
 
 
     if isnothing(initial_parameters)
-        initial_parameters = numpy.empty([ansatz_isa.num_parameters])
-        for i in 1:pyconvert(Int, ansatz_isa.num_parameters)
-            initial_parameters[i-1] = numpy.random.rand()
-        end
-    end
-
-    estimator = if is_local || ibm_backend == "ibmq_qasm_simulator"
-        qiskit_ibm_runtime.EstimatorV2(backend = backend)
+        initial_parameters = numpy.zeros(pyint(pyconvert(Int, ansatz_isa.num_parameters)))
     else
-        session = qiskit_ibm_runtime.Session(service=service, backend=backend)
-        qiskit_ibm_runtime.EstimatorV2(session=session)
-    end
-    if !is_local
-        estimator.options.default_shots = num_reads
+        initial_parameters = numpy.array(initial_parameters)
     end
 
-    println("Running VQE on $(ibm_backend)...")
+    estimator = qiskit_ibm_runtime.EstimatorV2(mode=backend)
+    estimator.options.default_shots = num_reads
     scipy_options = pydict()
     scipy_options["maxiter"] = max_iter
     result = scipy.optimize.minimize(
         cost_function,
         initial_parameters,
-        args = (ansatz_isa, ising_hamiltonian, estimator),
-        method = "cobyla",
-        options = scipy_options
+        args=(ansatz_isa, ising_hamiltonian, estimator),
+        method="cobyla",
+        options=scipy_options,
     )
 
     qc = ansatz.assign_parameters(result.x)
     qc.measure_all()
     optimized_qc = pass_manager.run(qc)
 
-    qiskit_sampler = qiskit.primitives.StatevectorSampler(default_shots = pyint(num_reads))
-    sampling_result = qiskit_sampler.run(pylist([optimized_qc])).result()[0]
+    qiskit_sampler = qiskit_ibm_runtime.SamplerV2(mode=backend)
+    sampling_result = qiskit_sampler.run(pylist([optimized_qc]), shots=pyint(num_reads)).result()[0]
     samples = sampling_result.data.meas.get_counts()
 
     callback(result, samples)
 
-    return nothing
+    return empty_metadata("VQE", backend_label, execution_mode)
 end
 
 end # module VQE

--- a/src/VQE.jl
+++ b/src/VQE.jl
@@ -3,6 +3,7 @@ module VQE
 using PythonCall: pyconvert, pylist, pydict, pyint, @pyexec
 using ..QiskitOpt:
     backend_name,
+    default_local_backend,
     empty_metadata,
     qiskit,
     qiskit_ibm_runtime,
@@ -26,7 +27,7 @@ QUBODrivers.@setup Optimizer begin
         MaximumIterations["max_iter"]::Integer     = 15
         NumberOfReads["num_reads"]::Integer        = 100
         InitialParameters["initial_parameters"]::Union{Vector{Float64}, Nothing} = nothing 
-        IBMFakeBackend["ibm_fake_backend"]         = qiskit_ibm_runtime.fake_provider.FakeManilaV2
+        IBMFakeBackend["ibm_fake_backend"]         = default_local_backend
         IBMBackend["ibm_backend"]::Union{String, Nothing} = nothing
         IsLocal["is_local"]::Bool                  = false
         Channel["channel"]::Union{String, Nothing} = nothing

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,2 @@
 [deps]
-JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
-using JuMP
 using Test
 using QiskitOpt
 using QiskitOpt: QAOA, QUBODrivers, VQE
+
+MOI = QUBODrivers.MOI
 
 const TEST_Q = [
     -1 2 2
@@ -71,29 +72,42 @@ struct MockRuntimeService
 end
 
 function build_model(optimizer_factory; Q=TEST_Q, L=nothing, scale=1.0, offset=0.0, sense=:Min)
-    model = Model(optimizer_factory)
+    model = MOI.instantiate(optimizer_factory; with_cache_type=Float64)
     num_variables = size(Q, 1)
     linear_coefficients = isnothing(L) ? zeros(num_variables) : L
 
-    @variable(model, x[1:num_variables], Bin)
-
-    quadratic = sum(Q[i, j] * x[i] * x[j] for i in 1:num_variables, j in 1:num_variables)
-    linear = sum(linear_coefficients[i] * x[i] for i in 1:num_variables)
-    objective = scale * (quadratic + linear + offset)
-    if sense == :Min
-        @objective(model, Min, objective)
-    else
-        @objective(model, Max, objective)
+    x = MOI.add_variables(model, num_variables)
+    for variable in x
+        MOI.add_constraint(model, variable, MOI.ZeroOne())
     end
+
+    quadratic_terms = MOI.ScalarQuadraticTerm{Float64}[]
+    for i in 1:num_variables, j in 1:num_variables
+        iszero(Q[i, j]) && continue
+        coefficient = (i == j ? 2 : 1) * scale * Q[i, j]
+        push!(quadratic_terms, MOI.ScalarQuadraticTerm(coefficient, x[i], x[j]))
+    end
+
+    linear_terms = MOI.ScalarAffineTerm{Float64}[]
+    for i in 1:num_variables
+        iszero(linear_coefficients[i]) && continue
+        push!(linear_terms, MOI.ScalarAffineTerm(scale * linear_coefficients[i], x[i]))
+    end
+
+    objective = MOI.ScalarQuadraticFunction(quadratic_terms, linear_terms, scale * offset)
+    objective_sense = sense == :Min ? MOI.MIN_SENSE : MOI.MAX_SENSE
+    MOI.set(model, MOI.ObjectiveSense(), objective_sense)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(objective)}(), objective)
 
     return model, x
 end
 
 function assert_solution_consistency(model, x; Q=TEST_Q, L=nothing, scale=1.0, offset=0.0)
-    @test result_count(model) >= 1
+    result_count = MOI.get(model, MOI.ResultCount())
+    @test result_count >= 1
 
-    for result in 1:result_count(model)
-        assignment = round.(Int, value.(x; result=result))
+    for result in 1:result_count
+        assignment = round.(Int, MOI.get.(model, MOI.VariablePrimal(result), x))
         linear_coefficients = isnothing(L) ? zeros(length(assignment)) : L
         expected_objective =
             scale * (
@@ -101,15 +115,15 @@ function assert_solution_consistency(model, x; Q=TEST_Q, L=nothing, scale=1.0, o
                 sum(linear_coefficients[i] * assignment[i] for i in eachindex(assignment)) +
                 offset
             )
-        observed_objective = objective_value(model; result=result)
+        observed_objective = MOI.get(model, MOI.ObjectiveValue(result))
 
         @test isapprox(observed_objective, expected_objective; atol=1.0e-6)
     end
 end
 
 function configure_solver!(model, optimizer_module; max_iterations=5, number_of_reads=64)
-    set_attribute(model, optimizer_module.MaximumIterations(), max_iterations)
-    set_attribute(model, optimizer_module.NumberOfReads(), number_of_reads)
+    MOI.set(model, optimizer_module.MaximumIterations(), max_iterations)
+    MOI.set(model, optimizer_module.NumberOfReads(), number_of_reads)
 end
 
 function solve_locally_without_runtime_service(
@@ -146,7 +160,7 @@ function solve_locally_without_runtime_service(
                 sense=sense,
             )
             for (index, value) in fixed_variables
-                fix(x[index], value; force=true)
+                MOI.add_constraint(model, x[index], MOI.EqualTo(Float64(value)))
             end
             configure_solver!(
                 model,
@@ -155,7 +169,7 @@ function solve_locally_without_runtime_service(
                 number_of_reads=number_of_reads,
             )
 
-            optimize!(model)
+            MOI.optimize!(model)
             assert_solution_consistency(model, x; Q=Q, L=L, scale=scale, offset=offset)
         finally
             QiskitOpt._runtime_service_builder[] = previous_builder
@@ -165,8 +179,8 @@ end
 
 function run_qubodrivers_suite(optimizer_module)
     QUBODrivers.test(optimizer_module.Optimizer) do model
-        QUBODrivers.MOI.set(model, optimizer_module.MaximumIterations(), 5)
-        QUBODrivers.MOI.set(model, optimizer_module.NumberOfReads(), 64)
+        MOI.set(model, optimizer_module.MaximumIterations(), 5)
+        MOI.set(model, optimizer_module.NumberOfReads(), 64)
     end
 end
 
@@ -201,10 +215,10 @@ end
 
     try
         model, _ = build_model(QAOA.Optimizer)
-        set_attribute(model, QAOA.IBMBackend(), "ibm_fez")
-        set_attribute(model, QAOA.MaximumIterations(), 1)
+        MOI.set(model, QAOA.IBMBackend(), "ibm_fez")
+        MOI.set(model, QAOA.MaximumIterations(), 1)
 
-        @test_throws ErrorException optimize!(model)
+        @test_throws ErrorException MOI.optimize!(model)
     finally
         QiskitOpt._runtime_service_builder[] = previous_builder
     end
@@ -225,12 +239,12 @@ end
 
         try
             model, x = build_model(VQE.Optimizer)
-            set_attribute(model, VQE.IBMBackend(), "ibm_fez")
-            set_attribute(model, VQE.IsLocal(), true)
-            set_attribute(model, VQE.MaximumIterations(), 2)
-            set_attribute(model, VQE.NumberOfReads(), 32)
+            MOI.set(model, VQE.IBMBackend(), "ibm_fez")
+            MOI.set(model, VQE.IsLocal(), true)
+            MOI.set(model, VQE.MaximumIterations(), 2)
+            MOI.set(model, VQE.NumberOfReads(), 32)
 
-            optimize!(model)
+            MOI.optimize!(model)
             assert_solution_consistency(model, x)
 
             @test length(runtime_calls) == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,32 +9,57 @@ const TEST_Q = [
     2 2 -1
 ]
 
+const FIXED_VARIABLE_Q = [
+    -1 2 0 1
+    2 -1 2 0
+    0 2 -1 2
+    1 0 2 -1
+]
+
 struct MockRuntimeService
     backend::Function
 end
 
-function build_model(optimizer_factory)
+function build_model(optimizer_factory; Q=TEST_Q, sense=:Min)
     model = Model(optimizer_factory)
+    num_variables = size(Q, 1)
 
-    @variable(model, x[1:3], Bin)
-    @objective(model, Min, sum(TEST_Q[i, j] * x[i] * x[j] for i in 1:3, j in 1:3))
+    @variable(model, x[1:num_variables], Bin)
+
+    objective = sum(Q[i, j] * x[i] * x[j] for i in 1:num_variables, j in 1:num_variables)
+    if sense == :Min
+        @objective(model, Min, objective)
+    else
+        @objective(model, Max, objective)
+    end
 
     return model, x
 end
 
-function assert_solution_consistency(model, x)
+function assert_solution_consistency(model, x; Q=TEST_Q)
     @test result_count(model) >= 1
 
     for result in 1:result_count(model)
         assignment = round.(Int, value.(x; result=result))
-        expected_objective = assignment' * TEST_Q * assignment
+        expected_objective = assignment' * Q * assignment
         observed_objective = objective_value(model; result=result)
 
         @test isapprox(observed_objective, expected_objective; atol=1.0e-6)
     end
 end
 
-function solve_locally_without_runtime_service(optimizer_factory, optimizer_module)
+function configure_solver!(model, optimizer_module; max_iterations=5, number_of_reads=64)
+    set_attribute(model, optimizer_module.MaximumIterations(), max_iterations)
+    set_attribute(model, optimizer_module.NumberOfReads(), number_of_reads)
+end
+
+function solve_locally_without_runtime_service(
+    optimizer_factory,
+    optimizer_module;
+    Q=TEST_Q,
+    sense=:Min,
+    fixed_variables=Pair{Int,Int}[],
+)
     withenv(
         "QISKIT_IBM_TOKEN" => nothing,
         "QISKIT_IBM_INSTANCE" => nothing,
@@ -48,12 +73,14 @@ function solve_locally_without_runtime_service(optimizer_factory, optimizer_modu
         )
 
         try
-            model, x = build_model(optimizer_factory)
-            set_attribute(model, optimizer_module.MaximumIterations(), 5)
-            set_attribute(model, optimizer_module.NumberOfReads(), 64)
+            model, x = build_model(optimizer_factory; Q=Q, sense=sense)
+            for (index, value) in fixed_variables
+                fix(x[index], value; force=true)
+            end
+            configure_solver!(model, optimizer_module)
 
             optimize!(model)
-            assert_solution_consistency(model, x)
+            assert_solution_consistency(model, x; Q=Q)
         finally
             QiskitOpt._runtime_service_builder[] = previous_builder
         end
@@ -70,6 +97,26 @@ end
 @testset "Local-first execution" begin
     solve_locally_without_runtime_service(QAOA.Optimizer, QAOA)
     solve_locally_without_runtime_service(VQE.Optimizer, VQE)
+end
+
+@testset "Max-sense objective reporting stays consistent" begin
+    solve_locally_without_runtime_service(QAOA.Optimizer, QAOA; sense=:Max)
+    solve_locally_without_runtime_service(VQE.Optimizer, VQE; sense=:Max)
+end
+
+@testset "Runtime configuration helpers preserve compatibility aliases" begin
+    withenv(
+        "QISKIT_IBM_TOKEN" => nothing,
+        "QISKIT_IBM_INSTANCE" => nothing,
+        "QISKIT_IBM_CHANNEL" => "ibm_quantum",
+        "IBMQ_API_TOKEN" => "legacy-token",
+        "IBMQ_INSTANCE" => "legacy-instance",
+    ) do
+        @test QiskitOpt.runtime_token() == "legacy-token"
+        @test QiskitOpt.runtime_instance() == "legacy-instance"
+        @test QiskitOpt.runtime_channel() == QiskitOpt.DEFAULT_RUNTIME_CHANNEL
+        @test QiskitOpt.runtime_channel("ibm_quantum") == QiskitOpt.DEFAULT_RUNTIME_CHANNEL
+    end
 end
 
 @testset "Runtime service stays opt-in" begin
@@ -120,6 +167,15 @@ end
             QiskitOpt._runtime_service_builder[] = previous_builder
         end
     end
+end
+
+@testset "VQE handles fixed-variable reductions" begin
+    solve_locally_without_runtime_service(
+        VQE.Optimizer,
+        VQE;
+        Q=FIXED_VARIABLE_Q,
+        fixed_variables=[4 => 1],
+    )
 end
 
 @testset "QUBODrivers compatibility suite" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,128 @@
-using QiskitOpt: QUBODrivers, VQE, QAOA
+using JuMP
+using Test
+using QiskitOpt
+using QiskitOpt: QAOA, QUBODrivers, VQE
 
-QUBODrivers.test(QAOA.Optimizer) do model
+const TEST_Q = [
+    -1 2 2
+    2 -1 2
+    2 2 -1
+]
+
+struct MockRuntimeService
+    backend::Function
 end
-QUBODrivers.test(VQE.Optimizer) do model
+
+function build_model(optimizer_factory)
+    model = Model(optimizer_factory)
+
+    @variable(model, x[1:3], Bin)
+    @objective(model, Min, sum(TEST_Q[i, j] * x[i] * x[j] for i in 1:3, j in 1:3))
+
+    return model, x
+end
+
+function assert_solution_consistency(model, x)
+    @test result_count(model) >= 1
+
+    for result in 1:result_count(model)
+        assignment = round.(Int, value.(x; result=result))
+        expected_objective = assignment' * TEST_Q * assignment
+        observed_objective = objective_value(model; result=result)
+
+        @test isapprox(observed_objective, expected_objective; atol=1.0e-6)
+    end
+end
+
+function solve_locally_without_runtime_service(optimizer_factory, optimizer_module)
+    withenv(
+        "QISKIT_IBM_TOKEN" => nothing,
+        "QISKIT_IBM_INSTANCE" => nothing,
+        "QISKIT_IBM_CHANNEL" => nothing,
+        "IBMQ_API_TOKEN" => nothing,
+        "IBMQ_INSTANCE" => nothing,
+    ) do
+        previous_builder = QiskitOpt._runtime_service_builder[]
+        QiskitOpt._runtime_service_builder[] = (; kwargs...) -> error(
+            "runtime service should not be created for local execution",
+        )
+
+        try
+            model, x = build_model(optimizer_factory)
+            set_attribute(model, optimizer_module.MaximumIterations(), 5)
+            set_attribute(model, optimizer_module.NumberOfReads(), 64)
+
+            optimize!(model)
+            assert_solution_consistency(model, x)
+        finally
+            QiskitOpt._runtime_service_builder[] = previous_builder
+        end
+    end
+end
+
+function run_qubodrivers_suite(optimizer_module)
+    QUBODrivers.test(optimizer_module.Optimizer) do model
+        QUBODrivers.MOI.set(model, optimizer_module.MaximumIterations(), 5)
+        QUBODrivers.MOI.set(model, optimizer_module.NumberOfReads(), 64)
+    end
+end
+
+@testset "Local-first execution" begin
+    solve_locally_without_runtime_service(QAOA.Optimizer, QAOA)
+    solve_locally_without_runtime_service(VQE.Optimizer, VQE)
+end
+
+@testset "Runtime service stays opt-in" begin
+    previous_builder = QiskitOpt._runtime_service_builder[]
+    QiskitOpt._runtime_service_builder[] = (; kwargs...) -> error("runtime service invoked")
+
+    try
+        model, _ = build_model(QAOA.Optimizer)
+        set_attribute(model, QAOA.IBMBackend(), "ibm_fez")
+        set_attribute(model, QAOA.MaximumIterations(), 1)
+
+        @test_throws ErrorException optimize!(model)
+    finally
+        QiskitOpt._runtime_service_builder[] = previous_builder
+    end
+end
+
+@testset "Named backend local emulation uses env-configured runtime service" begin
+    withenv(
+        "QISKIT_IBM_TOKEN" => "token-from-env",
+        "QISKIT_IBM_INSTANCE" => "instance-from-env",
+        "QISKIT_IBM_CHANNEL" => "channel-from-env",
+    ) do
+        runtime_calls = NamedTuple[]
+        previous_builder = QiskitOpt._runtime_service_builder[]
+        QiskitOpt._runtime_service_builder[] = (; channel, token, instance) -> begin
+            push!(runtime_calls, (channel=channel, token=token, instance=instance))
+            return MockRuntimeService(_ -> QiskitOpt.qiskit_ibm_runtime.fake_provider.FakeManilaV2())
+        end
+
+        try
+            model, x = build_model(VQE.Optimizer)
+            set_attribute(model, VQE.IBMBackend(), "ibm_fez")
+            set_attribute(model, VQE.IsLocal(), true)
+            set_attribute(model, VQE.MaximumIterations(), 2)
+            set_attribute(model, VQE.NumberOfReads(), 32)
+
+            optimize!(model)
+            assert_solution_consistency(model, x)
+
+            @test length(runtime_calls) == 1
+            @test runtime_calls[1] == (
+                channel="channel-from-env",
+                token="token-from-env",
+                instance="instance-from-env",
+            )
+        finally
+            QiskitOpt._runtime_service_builder[] = previous_builder
+        end
+    end
+end
+
+@testset "QUBODrivers compatibility suite" begin
+    run_qubodrivers_suite(QAOA)
+    run_qubodrivers_suite(VQE)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,17 +16,70 @@ const FIXED_VARIABLE_Q = [
     1 0 2 -1
 ]
 
+# Mirrors the 36-variable shape from issue #8 without vendoring external CSV data.
+const LARGE_LOCAL_Q = let Q = zeros(36, 36)
+    for i in 1:35
+        Q[i, i + 1] = isodd(i) ? -3.0 : 2.0
+    end
+    for i in 1:6:30
+        Q[i, i + 5] = -1.5
+    end
+    Q
+end
+
+const LARGE_LOCAL_L = [
+    39.7483,
+    -42.7194,
+    -42.7084,
+    -85.3741,
+    85.4966,
+    -42.7483,
+    175.9522,
+    85.4966,
+    48.9413,
+    52.4653,
+    -210.3895,
+    91.6596,
+    85.4966,
+    86.2356,
+    86.3366,
+    86.7676,
+    6.99,
+    172.3262,
+    0.0,
+    -42.7483,
+    -42.7483,
+    -42.7483,
+    -42.7483,
+    -42.7483,
+    -42.7483,
+    -42.7483,
+    -42.7483,
+    -42.7483,
+    -128.2449,
+    -128.2449,
+    128.2449,
+    128.2449,
+    128.2449,
+    42.7483,
+    42.7483,
+    42.7483,
+]
+
 struct MockRuntimeService
     backend::Function
 end
 
-function build_model(optimizer_factory; Q=TEST_Q, sense=:Min)
+function build_model(optimizer_factory; Q=TEST_Q, L=nothing, scale=1.0, offset=0.0, sense=:Min)
     model = Model(optimizer_factory)
     num_variables = size(Q, 1)
+    linear_coefficients = isnothing(L) ? zeros(num_variables) : L
 
     @variable(model, x[1:num_variables], Bin)
 
-    objective = sum(Q[i, j] * x[i] * x[j] for i in 1:num_variables, j in 1:num_variables)
+    quadratic = sum(Q[i, j] * x[i] * x[j] for i in 1:num_variables, j in 1:num_variables)
+    linear = sum(linear_coefficients[i] * x[i] for i in 1:num_variables)
+    objective = scale * (quadratic + linear + offset)
     if sense == :Min
         @objective(model, Min, objective)
     else
@@ -36,12 +89,18 @@ function build_model(optimizer_factory; Q=TEST_Q, sense=:Min)
     return model, x
 end
 
-function assert_solution_consistency(model, x; Q=TEST_Q)
+function assert_solution_consistency(model, x; Q=TEST_Q, L=nothing, scale=1.0, offset=0.0)
     @test result_count(model) >= 1
 
     for result in 1:result_count(model)
         assignment = round.(Int, value.(x; result=result))
-        expected_objective = assignment' * Q * assignment
+        linear_coefficients = isnothing(L) ? zeros(length(assignment)) : L
+        expected_objective =
+            scale * (
+                assignment' * Q * assignment +
+                sum(linear_coefficients[i] * assignment[i] for i in eachindex(assignment)) +
+                offset
+            )
         observed_objective = objective_value(model; result=result)
 
         @test isapprox(observed_objective, expected_objective; atol=1.0e-6)
@@ -57,8 +116,13 @@ function solve_locally_without_runtime_service(
     optimizer_factory,
     optimizer_module;
     Q=TEST_Q,
+    L=nothing,
+    scale=1.0,
+    offset=0.0,
     sense=:Min,
     fixed_variables=Pair{Int,Int}[],
+    max_iterations=5,
+    number_of_reads=64,
 )
     withenv(
         "QISKIT_IBM_TOKEN" => nothing,
@@ -73,14 +137,26 @@ function solve_locally_without_runtime_service(
         )
 
         try
-            model, x = build_model(optimizer_factory; Q=Q, sense=sense)
+            model, x = build_model(
+                optimizer_factory;
+                Q=Q,
+                L=L,
+                scale=scale,
+                offset=offset,
+                sense=sense,
+            )
             for (index, value) in fixed_variables
                 fix(x[index], value; force=true)
             end
-            configure_solver!(model, optimizer_module)
+            configure_solver!(
+                model,
+                optimizer_module;
+                max_iterations=max_iterations,
+                number_of_reads=number_of_reads,
+            )
 
             optimize!(model)
-            assert_solution_consistency(model, x; Q=Q)
+            assert_solution_consistency(model, x; Q=Q, L=L, scale=scale, offset=offset)
         finally
             QiskitOpt._runtime_service_builder[] = previous_builder
         end
@@ -175,6 +251,27 @@ end
         VQE;
         Q=FIXED_VARIABLE_Q,
         fixed_variables=[4 => 1],
+    )
+end
+
+@testset "Default local backend handles large QUBOs" begin
+    solve_locally_without_runtime_service(
+        QAOA.Optimizer,
+        QAOA;
+        Q=LARGE_LOCAL_Q,
+        L=LARGE_LOCAL_L,
+        offset=601.4762,
+        max_iterations=1,
+        number_of_reads=8,
+    )
+    solve_locally_without_runtime_service(
+        VQE.Optimizer,
+        VQE;
+        Q=LARGE_LOCAL_Q,
+        L=LARGE_LOCAL_L,
+        offset=601.4762,
+        max_iterations=1,
+        number_of_reads=8,
     )
 end
 


### PR DESCRIPTION
## Summary
- modernize QiskitOpt around a reproducible Julia/Qiskit 2 local-first stack
- make runtime and credential handling lazy so package import stays side-effect free
- add solver compatibility coverage through the upstream QUBODrivers suite and refreshed GitHub workflows

## Related issues
- Fixes #5
- Fixes #6
- Fixes #8

## What changed
- updated Julia and Python dependency bounds for `QUBO 0.4`, `QUBODrivers 0.3`, Python 3.11, and the current Qiskit 2 package line
- refactored QAOA and VQE to use lazy runtime service construction, backend-consistent `EstimatorV2` and `SamplerV2`, and correct objective reporting for both min and max sense
- made local execution credential-free by default through Aer matrix-product-state simulation, while keeping fake IBM backends and real IBM Quantum Platform support opt-in
- fixed VQE fixed-variable reductions by sizing the ansatz from the reduced Ising Hamiltonian instead of the original model variable count
- rewrote the tests to cover local execution, env-driven runtime configuration, a 36-variable large-QUBO local regression, and the full `QUBODrivers.test` compatibility suite for both solvers
- refreshed the README for local-first usage, local execution mode selection, and current IBM Quantum Platform configuration
- updated CI and added non-blocking dependency-drift and IBM hardware smoke workflows

## Why
The repository had drifted into a state where fresh checkouts were not reproducible, import-time auth behavior was unsafe, local execution was under-tested, and the solver implementations no longer matched the expectations of the surrounding QUBODrivers ecosystem.

## Impact
Users get a local-first package that runs from a fresh checkout without IBM credentials, can handle local QUBOs larger than the old five-qubit fake backend default, still supports real IBM backends when explicitly configured, and now exercises the same compatibility suite as the rest of the JuliaQUBO solver ecosystem.

## Root causes fixed
- stale dependency pins and unreproducible Python environment setup
- import-time account mutation through `save_account()`
- backend-inconsistent sampling and incorrect objective sign handling for maximization cases
- VQE layout mismatches when fixed variables reduced the active qubit count
- default local execution was tied to `FakeManilaV2`, which rejected QUBOs with more than five variables before simulation
- insufficient regression coverage around runtime selection, larger local QUBOs, and solver compatibility
- ambiguous installation and authentication documentation for first-time users

## Validation
- `julia --project=. -e 'using Pkg; Pkg.test()'`
- SECQUOIA `ds-mfg/discrete_ip/julia_exports` reproduction with `QAOA.Optimizer`, `MaximumIterations() = 1`, and `NumberOfReads() = 8` returns 8 sampled results on the default local backend
- SECQUOIA `ds-mfg/discrete_ip/julia_exports` reproduction with `VQE.Optimizer`, `MaximumIterations() = 1`, and `NumberOfReads() = 8` returns 1 sampled result on the default local backend
- `julia --project=. -e 'using Test; using QiskitOpt; using QiskitOpt: QUBODrivers, QAOA, VQE; MOI = QUBODrivers.MOI; QUBODrivers.test(QAOA.Optimizer) do model; MOI.set(model, QAOA.MaximumIterations(), 5); MOI.set(model, QAOA.NumberOfReads(), 64); end; QUBODrivers.test(VQE.Optimizer) do model; MOI.set(model, VQE.MaximumIterations(), 5); MOI.set(model, VQE.NumberOfReads(), 64); end'`
