### PR TITLE
Modernize Julia CI and QUBO compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         include:
           - version: '1.10'
             os: ubuntu-latest
-          - version: '1.11'
+          - version: '1'
             os: ubuntu-latest
-          - version: '1.11'
+          - version: '1'
             os: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dependency-drift.yml
+++ b/.github/workflows/dependency-drift.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: "1.11"
+          version: "1"
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/ibm-hardware-smoke.yml
+++ b/.github/workflows/ibm-hardware-smoke.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: "1.11"
+          version: "1"
       - name: Check IBM runtime configuration
         id: config
         shell: bash

--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,4 @@ QUBO = "ce8c2e91-a970-4681-856b-16178c24a30c"
 [compat]
 PythonCall = "0.9"
 julia = "1.10"
-QUBO = "0.4"
+QUBO = "0.4, 0.5"


### PR DESCRIPTION
## Summary

- Allow QUBO `0.5` in package compat while preserving the existing `0.4` allowance.
- Update CI coverage to test the explicit Julia `1.10` floor plus latest stable Julia via `version: '1'`.
- Update the dependency drift and IBM hardware smoke workflows to use latest stable Julia instead of hard-coded `1.11`.
- Confirm the issue #10 cleanup is already present on the synced default branch: README links point to `JuliaQUBO` repositories and `Project.toml` includes `bernalde <dbernaln@purdue.edu>`.

## Tests run

- `julia +1.10 -e 'import Pkg; Pkg.activate(; temp=true); Pkg.develop(Pkg.PackageSpec(path=pwd())); Pkg.instantiate(); deps = Pkg.dependencies(); matches = [dep for dep in values(deps) if dep.name == "QUBO"]; isempty(matches) && error("QUBO not resolved"); println("QUBO ", matches[1].version)'`
  - Passed; resolved `QUBO 0.5.0`.
- `julia +1.10 --project=. -e 'import Pkg; Pkg.build(); Pkg.test()'`
  - Passed. This exercised the local CI-equivalent command, though an existing untracked root manifest resolved QUBO `0.4.0`.
- `julia +1.10 -e 'import Pkg; Pkg.activate(; temp=true); Pkg.develop(Pkg.PackageSpec(path=pwd())); Pkg.test("QiskitOpt")'`
  - Passed; resolved `QUBO 0.5.0`.
- `julia +1.12 -e 'import Pkg; Pkg.activate(; temp=true); Pkg.develop(Pkg.PackageSpec(path=pwd())); Pkg.test("QiskitOpt")'`
  - Passed; resolved `QUBO 0.5.0`.

## Notes

- No docs workflow or docs directory was present to build locally.
- The IBM hardware smoke workflow was not run locally because it requires repository IBM Quantum credentials and backend configuration.

Closes #9
Closes #10
