### PR TITLE
Add Dependabot maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
## Summary

- Add the standard JuliaQUBO Dependabot configuration for the root Julia project, grouped weekly.
- Add monthly Dependabot updates for GitHub Actions.
- Update the CI push trigger from `master` to `main`.

This follows the final JuliaQUBO dependency maintenance policy from JuliaQUBO/QUBO.jl#30/#31: use Dependabot by default for public Julia package repositories that rely on the General registry, and do not add CompatHelper unless a custom or private registry requires it.

QiskitOpt.jl has no `docs/` environment or documentation workflow, so the Dependabot-only `--skip-deploy` docs path used in other repositories is not needed here. The existing dependency drift workflow remains complementary latest-stack testing and does not replace Dependabot's compat-bound update PRs.

Dependabot does not require a repository PAT or additional secret for this public General-registry Julia setup; the default Dependabot/GitHub token behavior is sufficient for opening dependency update PRs.

Closes #12.

## Tests

- `git diff --check` - passed.
- `rg --hidden --glob '!.git/**' -n "\bmaster\b|/master|master\]" .` - no remaining committed-source matches.

Julia tests were not run because this PR changes only GitHub maintenance configuration.
