### PR TITLE
Add runtime diagnostics and lazy Python imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ for i = 1:result_count(model)
 end
 ```
 
+## Runtime Diagnostics
+Use `check_runtime` to verify the Julia/Python bridge and local Qiskit stack before running an optimizer:
+
+```julia
+using QiskitOpt
+
+diagnostics = QiskitOpt.check_runtime(; local_backend=true, ibm=false)
+diagnostics.ok
+```
+
+Julia reserves `local` as syntax, so the Julia-callable keyword is `local_backend`.
+With `ibm=false`, diagnostics do not import `qiskit_ibm_runtime`. Set `ibm=true` when you want IBM Runtime availability reported separately.
+
 ## Updating optimization parameters
 
 ```julia

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ diagnostics.ok
 
 Julia reserves `local` as syntax, so the Julia-callable keyword is `local_backend`.
 With `ibm=false`, diagnostics do not import `qiskit_ibm_runtime`. Set `ibm=true` when you want IBM Runtime availability reported separately.
+The local backend check verifies the default Aer backend. Current QAOA/VQE local solves still use `qiskit_ibm_runtime` `EstimatorV2` and `SamplerV2` primitives, so run with `ibm=true` when you want a full solver-readiness check.
 
 ## Updating optimization parameters
 

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -90,7 +90,7 @@ function retrieve(
     else
         remote_backend = runtime_service(channel=channel, instance=instance).backend(ibm_backend)
         if is_local
-            (qiskit_aer.AerSimulator.from_backend(remote_backend), "local")
+            (qiskit_aer().AerSimulator.from_backend(remote_backend), "local")
         else
             (remote_backend, "cloud")
         end
@@ -99,12 +99,12 @@ function retrieve(
 
     ising_qp = quadratic_program(sampler)
     ising_hamiltonian = ising_qp[0]
-    ansatz = qiskit.circuit.library.QAOAAnsatz(
+    ansatz = qiskit().circuit.library.QAOAAnsatz(
         ising_hamiltonian,
         reps=num_layers,
     )
 
-    pass_manager = qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager(
+    pass_manager = qiskit().transpiler.preset_passmanagers.generate_preset_pass_manager(
         backend=backend,
         optimization_level=3,
     )
@@ -114,16 +114,16 @@ function retrieve(
 
 
     if isnothing(initial_parameters)
-        initial_parameters = numpy.zeros(pyint(pyconvert(Int, ansatz_isa.num_parameters)))
+        initial_parameters = numpy().zeros(pyint(pyconvert(Int, ansatz_isa.num_parameters)))
     else
-        initial_parameters = numpy.array(initial_parameters)
+        initial_parameters = numpy().array(initial_parameters)
     end
 
-    estimator = qiskit_ibm_runtime.EstimatorV2(mode=backend)
+    estimator = qiskit_ibm_runtime().EstimatorV2(mode=backend)
     estimator.options.default_shots = num_reads
     scipy_options = pydict()
     scipy_options["maxiter"] = max_iter
-    result = scipy.optimize.minimize(
+    result = scipy().optimize.minimize(
         cost_function,
         initial_parameters,
         args=(ansatz_isa, ising_hamiltonian, estimator),
@@ -135,7 +135,7 @@ function retrieve(
     qc.measure_all()
     optimized_qc = pass_manager.run(qc)
 
-    qiskit_sampler = qiskit_ibm_runtime.SamplerV2(mode=backend)
+    qiskit_sampler = qiskit_ibm_runtime().SamplerV2(mode=backend)
     sampling_result = qiskit_sampler.run(pylist([optimized_qc]), shots=pyint(num_reads)).result()[0]
     samples = sampling_result.data.meas.get_counts()
 

--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -116,6 +116,8 @@ const qiskit_aer          = LazyPythonModule("qiskit_aer", "qiskit-aer")
 const scipy               = LazyPythonModule("scipy", "scipy")
 const numpy               = LazyPythonModule("numpy", "numpy")
 const _runtime_service_builder = Ref{Function}()
+const _LOCAL_SOLVER_PRIMITIVES_NOTE =
+    "QAOA/VQE local solves still use qiskit_ibm_runtime EstimatorV2/SamplerV2; pass ibm=true to verify those primitives."
 
 function __init__()
     foreach(
@@ -199,7 +201,7 @@ function _diagnose_local_backend()
         return RuntimeDiagnostic(
             name="default_local_backend",
             ok=true,
-            message="Usable backend: $(backend_name(backend))",
+            message="Usable backend: $(backend_name(backend)). $(_LOCAL_SOLVER_PRIMITIVES_NOTE)",
         )
     catch err
         return RuntimeDiagnostic(
@@ -256,7 +258,6 @@ function check_runtime(; local_backend::Bool=true, ibm::Bool=false, verbose::Boo
 
     ibm_runtime = if ibm
         diagnostic = _diagnose_python_module(qiskit_ibm_runtime)
-        packages[diagnostic.name] = diagnostic
         diagnostic
     else
         nothing
@@ -266,6 +267,9 @@ function check_runtime(; local_backend::Bool=true, ibm::Bool=false, verbose::Boo
 
     diagnostics = RuntimeDiagnostic[julia, pythoncall]
     append!(diagnostics, values(packages))
+    if !isnothing(ibm_runtime)
+        push!(diagnostics, ibm_runtime)
+    end
     if !isnothing(local_backend_diagnostic)
         push!(diagnostics, local_backend_diagnostic)
     end

--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -6,24 +6,281 @@ MOI = QUBODrivers.MOI
 
 const DEFAULT_RUNTIME_CHANNEL = "ibm_quantum_platform"
 
+struct PythonPackageError <: Exception
+    module_name::String
+    package_name::String
+    python_executable::Union{Nothing,String}
+    cause::String
+end
+
+function Base.showerror(io::IO, err::PythonPackageError)
+    python = isnothing(err.python_executable) ? "unknown" : err.python_executable
+    print(
+        io,
+        "Python package '$(err.package_name)' (import name '$(err.module_name)') could not be imported. ",
+        "Python executable: $(python). ",
+        "Install '$(err.package_name)' into that Python environment or configure PythonCall to use one that provides it.",
+    )
+    if !isempty(err.cause)
+        print(io, "\nOriginal error: ", err.cause)
+    end
+end
+
+Base.@kwdef struct RuntimeDiagnostic
+    name::String
+    ok::Bool
+    version::Union{Nothing,String} = nothing
+    message::String = ""
+end
+
+Base.@kwdef struct RuntimeDiagnostics
+    ok::Bool
+    julia::RuntimeDiagnostic
+    pythoncall::RuntimeDiagnostic
+    packages::Dict{String,RuntimeDiagnostic}
+    local_backend::Union{Nothing,RuntimeDiagnostic} = nothing
+    ibm_runtime::Union{Nothing,RuntimeDiagnostic} = nothing
+end
+
+struct LazyPythonModule
+    module_name::String
+    package_name::String
+    cache::Base.RefValue{Any}
+end
+
+function LazyPythonModule(module_name::AbstractString, package_name::AbstractString)
+    return LazyPythonModule(String(module_name), String(package_name), Ref{Any}(nothing))
+end
+
+function LazyPythonModule(module_name::AbstractString)
+    return LazyPythonModule(module_name, replace(String(module_name), "_" => "-"))
+end
+
+function _reset_python_module!(lazy_module::LazyPythonModule)
+    lazy_module.cache[] = nothing
+    return lazy_module
+end
+
+function python_executable()
+    try
+        return PythonCall.pyconvert(String, PythonCall.pyimport("sys").executable)
+    catch
+        return nothing
+    end
+end
+
+function _import_python_module(module_name::AbstractString, package_name::AbstractString)
+    try
+        return PythonCall.pyimport(module_name)
+    catch err
+        throw(
+            PythonPackageError(
+                String(module_name),
+                String(package_name),
+                python_executable(),
+                sprint(showerror, err),
+            ),
+        )
+    end
+end
+
+function _load_python_module!(lazy_module::LazyPythonModule)
+    cached = lazy_module.cache[]
+    cached !== nothing && return cached
+
+    loaded = _import_python_module(lazy_module.module_name, lazy_module.package_name)
+    lazy_module.cache[] = loaded
+    return loaded
+end
+
+(lazy_module::LazyPythonModule)() = _load_python_module!(lazy_module)
+
+function Base.getproperty(lazy_module::LazyPythonModule, name::Symbol)
+    if name === :module_name || name === :package_name || name === :cache
+        return getfield(lazy_module, name)
+    end
+
+    return getproperty(_load_python_module!(lazy_module), name)
+end
+
+function Base.show(io::IO, lazy_module::LazyPythonModule)
+    status = lazy_module.cache[] === nothing ? "not loaded" : "loaded"
+    print(io, "LazyPythonModule(", lazy_module.module_name, ", ", status, ")")
+end
+
 # :: Python Qiskit Modules ::
-const qiskit              = PythonCall.pynew()
-const qiskit_optimization = PythonCall.pynew()
-const qiskit_ibm_runtime  = PythonCall.pynew()
-const qiskit_aer          = PythonCall.pynew()  
-const scipy               = PythonCall.pynew()
-const numpy               = PythonCall.pynew()
+const qiskit              = LazyPythonModule("qiskit", "qiskit")
+const qiskit_optimization = LazyPythonModule("qiskit_optimization", "qiskit-optimization")
+const qiskit_ibm_runtime  = LazyPythonModule("qiskit_ibm_runtime", "qiskit-ibm-runtime")
+const qiskit_aer          = LazyPythonModule("qiskit_aer", "qiskit-aer")
+const scipy               = LazyPythonModule("scipy", "scipy")
+const numpy               = LazyPythonModule("numpy", "numpy")
 const _runtime_service_builder = Ref{Function}()
 
 function __init__()
-    # Load Python Packages
-    PythonCall.pycopy!(qiskit, pyimport("qiskit"))
-    PythonCall.pycopy!(qiskit_optimization, pyimport("qiskit_optimization"))
-    PythonCall.pycopy!(qiskit_ibm_runtime, pyimport("qiskit_ibm_runtime"))
-    PythonCall.pycopy!(qiskit_aer, pyimport("qiskit_aer"))
-    PythonCall.pycopy!(scipy, pyimport("scipy"))
-    PythonCall.pycopy!(numpy, pyimport("numpy"))
+    foreach(
+        _reset_python_module!,
+        (qiskit, qiskit_optimization, qiskit_ibm_runtime, qiskit_aer, scipy, numpy),
+    )
     _runtime_service_builder[] = default_runtime_service
+end
+
+function _diagnostic_error_message(err)
+    return sprint(showerror, err)
+end
+
+function _module_version(jl_module::Module)
+    try
+        version = Base.pkgversion(jl_module)
+        return isnothing(version) ? nothing : string(version)
+    catch
+        return nothing
+    end
+end
+
+function _python_module_version(py_module)
+    try
+        return PythonCall.pyconvert(String, getproperty(py_module, :__version__))
+    catch
+        return nothing
+    end
+end
+
+function _diagnose_julia_package()
+    version = _module_version(@__MODULE__)
+    return RuntimeDiagnostic(
+        name="QiskitOpt",
+        ok=true,
+        version=version,
+        message="Julia version: $(VERSION)",
+    )
+end
+
+function _diagnose_pythoncall()
+    executable = python_executable()
+    ok = !isnothing(executable)
+    message = ok ? "Python executable: $(executable)" : "Python executable could not be resolved"
+    return RuntimeDiagnostic(
+        name="PythonCall",
+        ok=ok,
+        version=_module_version(PythonCall),
+        message=message,
+    )
+end
+
+function _diagnose_python_module(lazy_module::LazyPythonModule)
+    try
+        loaded = _load_python_module!(lazy_module)
+        version = _python_module_version(loaded)
+        executable = python_executable()
+        message = isnothing(executable) ? "" : "Python executable: $(executable)"
+        return RuntimeDiagnostic(
+            name=lazy_module.module_name,
+            ok=true,
+            version=version,
+            message=message,
+        )
+    catch err
+        return RuntimeDiagnostic(
+            name=lazy_module.module_name,
+            ok=false,
+            message=_diagnostic_error_message(err),
+        )
+    end
+end
+
+function _diagnose_python_module(module_name::AbstractString, package_name::AbstractString)
+    return _diagnose_python_module(LazyPythonModule(module_name, package_name))
+end
+
+function _diagnose_local_backend()
+    try
+        backend = default_local_backend()
+        return RuntimeDiagnostic(
+            name="default_local_backend",
+            ok=true,
+            message="Usable backend: $(backend_name(backend))",
+        )
+    catch err
+        return RuntimeDiagnostic(
+            name="default_local_backend",
+            ok=false,
+            message=_diagnostic_error_message(err),
+        )
+    end
+end
+
+function _print_runtime_diagnostic(io::IO, label::AbstractString, diagnostic::RuntimeDiagnostic)
+    status = diagnostic.ok ? "OK" : "FAIL"
+    version = isnothing(diagnostic.version) ? "" : " ($(diagnostic.version))"
+    println(io, "  $(label): $(status)$(version)")
+    if !isempty(diagnostic.message)
+        println(io, "    ", replace(diagnostic.message, "\n" => "\n    "))
+    end
+end
+
+function _print_runtime_diagnostics(io::IO, result::RuntimeDiagnostics)
+    println(io, "QiskitOpt runtime diagnostics: ", result.ok ? "OK" : "FAILED")
+    _print_runtime_diagnostic(io, "Julia package", result.julia)
+    _print_runtime_diagnostic(io, "PythonCall", result.pythoncall)
+    for name in sort(collect(keys(result.packages)))
+        _print_runtime_diagnostic(io, name, result.packages[name])
+    end
+    if !isnothing(result.local_backend)
+        _print_runtime_diagnostic(io, "Local backend", result.local_backend)
+    end
+    if !isnothing(result.ibm_runtime)
+        _print_runtime_diagnostic(io, "IBM Runtime", result.ibm_runtime)
+    end
+    return nothing
+end
+
+function check_runtime(; local_backend::Bool=true, ibm::Bool=false, verbose::Bool=true, kwargs...)
+    unknown_keywords = setdiff(collect(keys(kwargs)), [:local])
+    if !isempty(unknown_keywords)
+        throw(ArgumentError("unsupported check_runtime keyword(s): $(join(unknown_keywords, ", "))"))
+    end
+    if haskey(kwargs, :local)
+        kwargs[:local] isa Bool || throw(ArgumentError("check_runtime local keyword must be a Bool"))
+        local_backend = kwargs[:local]
+    end
+
+    julia = _diagnose_julia_package()
+    pythoncall = _diagnose_pythoncall()
+    packages = Dict{String,RuntimeDiagnostic}()
+
+    for lazy_module in (qiskit, qiskit_aer, qiskit_optimization, scipy, numpy)
+        diagnostic = _diagnose_python_module(lazy_module)
+        packages[diagnostic.name] = diagnostic
+    end
+
+    ibm_runtime = if ibm
+        diagnostic = _diagnose_python_module(qiskit_ibm_runtime)
+        packages[diagnostic.name] = diagnostic
+        diagnostic
+    else
+        nothing
+    end
+
+    local_backend_diagnostic = local_backend ? _diagnose_local_backend() : nothing
+
+    diagnostics = RuntimeDiagnostic[julia, pythoncall]
+    append!(diagnostics, values(packages))
+    if !isnothing(local_backend_diagnostic)
+        push!(diagnostics, local_backend_diagnostic)
+    end
+
+    result = RuntimeDiagnostics(
+        ok=all(diagnostic -> diagnostic.ok, diagnostics),
+        julia=julia,
+        pythoncall=pythoncall,
+        packages=packages,
+        local_backend=local_backend_diagnostic,
+        ibm_runtime=ibm_runtime,
+    )
+
+    verbose && _print_runtime_diagnostics(stdout, result)
+    return result
 end
 
 function nonempty_or_nothing(value)
@@ -78,22 +335,23 @@ function default_runtime_service(;
     resolved_channel = runtime_channel(channel)
     resolved_token = nonempty_or_nothing(token)
     resolved_instance = runtime_instance(instance)
+    runtime = qiskit_ibm_runtime()
 
     if isnothing(resolved_token) && isnothing(resolved_instance)
-        return qiskit_ibm_runtime.QiskitRuntimeService(channel=resolved_channel)
+        return runtime.QiskitRuntimeService(channel=resolved_channel)
     elseif isnothing(resolved_token)
-        return qiskit_ibm_runtime.QiskitRuntimeService(
+        return runtime.QiskitRuntimeService(
             channel=resolved_channel,
             instance=resolved_instance,
         )
     elseif isnothing(resolved_instance)
-        return qiskit_ibm_runtime.QiskitRuntimeService(
+        return runtime.QiskitRuntimeService(
             channel=resolved_channel,
             token=resolved_token,
         )
     end
 
-    return qiskit_ibm_runtime.QiskitRuntimeService(
+    return runtime.QiskitRuntimeService(
         channel=resolved_channel,
         token=resolved_token,
         instance=resolved_instance,
@@ -112,7 +370,7 @@ function runtime_service(;
 end
 
 function default_local_backend()
-    return qiskit_aer.AerSimulator(method="matrix_product_state")
+    return qiskit_aer().AerSimulator(method="matrix_product_state")
 end
 
 function backend_name(backend)
@@ -156,7 +414,7 @@ function quadratic_program(sampler::QUBODrivers.AbstractSampler{T}) where {T}
         quadratic[variable_names[i], variable_names[j]] = Q[i,j] * (sense == MOI.MIN_SENSE ? 1 : -1)
     end
 
-    qp = qiskit_optimization.QuadraticProgram()
+    qp = qiskit_optimization().QuadraticProgram()
 
     for v in variable_names
         qp.binary_var(v)
@@ -167,7 +425,7 @@ function quadratic_program(sampler::QUBODrivers.AbstractSampler{T}) where {T}
     return qp.to_ising()
 end
 
-export  VQE, QAOA
+export  VQE, QAOA, check_runtime
 
 include("QAOA.jl")
 include("VQE.jl")

--- a/src/VQE.jl
+++ b/src/VQE.jl
@@ -21,6 +21,10 @@ MOI = QUBODrivers.MOI
 Sample = QUBODrivers.Sample
 SampleSet = QUBODrivers.SampleSet
 
+function default_ansatz(; kwargs...)
+    return qiskit().circuit.library.EfficientSU2(; kwargs...)
+end
+
 QUBODrivers.@setup Optimizer begin
     name    = "VQE @ IBM Quantum"
     attributes = begin
@@ -32,7 +36,7 @@ QUBODrivers.@setup Optimizer begin
         IsLocal["is_local"]::Bool                  = false
         Channel["channel"]::Union{String, Nothing} = nothing
         Instance["instance"]::Union{String, Nothing} = nothing
-        Ansatz["ansatz"]                           = qiskit.circuit.library.EfficientSU2
+        Ansatz["ansatz"]                           = default_ansatz
     end
 end
 
@@ -90,7 +94,7 @@ function retrieve(
     else
         remote_backend = runtime_service(channel=channel, instance=instance).backend(ibm_backend)
         if is_local
-            (qiskit_aer.AerSimulator.from_backend(remote_backend), "local")
+            (qiskit_aer().AerSimulator.from_backend(remote_backend), "local")
         else
             (remote_backend, "cloud")
         end
@@ -102,7 +106,7 @@ function retrieve(
     num_qubits = pyconvert(Int, ising_hamiltonian.num_qubits)
     ansatz = ansatz_instance(num_qubits=num_qubits)
 
-    pass_manager = qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager(
+    pass_manager = qiskit().transpiler.preset_passmanagers.generate_preset_pass_manager(
         backend=backend,
         optimization_level=3,
     )
@@ -112,16 +116,16 @@ function retrieve(
 
 
     if isnothing(initial_parameters)
-        initial_parameters = numpy.zeros(pyint(pyconvert(Int, ansatz_isa.num_parameters)))
+        initial_parameters = numpy().zeros(pyint(pyconvert(Int, ansatz_isa.num_parameters)))
     else
-        initial_parameters = numpy.array(initial_parameters)
+        initial_parameters = numpy().array(initial_parameters)
     end
 
-    estimator = qiskit_ibm_runtime.EstimatorV2(mode=backend)
+    estimator = qiskit_ibm_runtime().EstimatorV2(mode=backend)
     estimator.options.default_shots = num_reads
     scipy_options = pydict()
     scipy_options["maxiter"] = max_iter
-    result = scipy.optimize.minimize(
+    result = scipy().optimize.minimize(
         cost_function,
         initial_parameters,
         args=(ansatz_isa, ising_hamiltonian, estimator),
@@ -133,7 +137,7 @@ function retrieve(
     qc.measure_all()
     optimized_qc = pass_manager.run(qc)
 
-    qiskit_sampler = qiskit_ibm_runtime.SamplerV2(mode=backend)
+    qiskit_sampler = qiskit_ibm_runtime().SamplerV2(mode=backend)
     sampling_result = qiskit_sampler.run(pylist([optimized_qc]), shots=pyint(num_reads)).result()[0]
     samples = sampling_result.data.meas.get_counts()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,11 @@ const LARGE_LOCAL_L = [
     42.7483,
 ]
 
+function python_module_loaded(name)
+    sys = QiskitOpt.PythonCall.pyimport("sys")
+    return QiskitOpt.PythonCall.pyconvert(Bool, sys.modules.__contains__(name))
+end
+
 struct MockRuntimeService
     backend::Function
 end
@@ -182,6 +187,51 @@ function run_qubodrivers_suite(optimizer_module)
         MOI.set(model, optimizer_module.MaximumIterations(), 5)
         MOI.set(model, optimizer_module.NumberOfReads(), 64)
     end
+end
+
+@testset "Runtime diagnostics and lazy imports" begin
+    @test !python_module_loaded("qiskit_ibm_runtime")
+
+    local_diagnostics = QiskitOpt.check_runtime(; local_backend=true, ibm=false, verbose=false)
+    @test local_diagnostics.ok
+    @test local_diagnostics.packages["qiskit"].ok
+    @test local_diagnostics.packages["qiskit_aer"].ok
+    @test local_diagnostics.packages["qiskit_optimization"].ok
+    @test !isnothing(local_diagnostics.packages["qiskit"].version)
+    @test isnothing(local_diagnostics.ibm_runtime)
+    @test !haskey(local_diagnostics.packages, "qiskit_ibm_runtime")
+    @test !isnothing(local_diagnostics.local_backend)
+    @test local_diagnostics.local_backend.ok
+    @test !python_module_loaded("qiskit_ibm_runtime")
+
+    missing_error = try
+        QiskitOpt._import_python_module(
+            "qiskitopt_missing_python_package_for_test",
+            "qiskitopt-missing-python-package-for-test",
+        )
+    catch err
+        err
+    end
+    @test missing_error isa QiskitOpt.PythonPackageError
+    missing_message = sprint(showerror, missing_error)
+    @test occursin("qiskitopt-missing-python-package-for-test", missing_message)
+    @test occursin("Python executable:", missing_message)
+
+    missing_diagnostic = QiskitOpt._diagnose_python_module(
+        "qiskitopt_missing_python_package_for_test",
+        "qiskitopt-missing-python-package-for-test",
+    )
+    @test !missing_diagnostic.ok
+    @test occursin("qiskitopt-missing-python-package-for-test", missing_diagnostic.message)
+    @test occursin("Python executable:", missing_diagnostic.message)
+
+    pair_alias_diagnostics = QiskitOpt.check_runtime(; :local => false, ibm=false, verbose=false)
+    @test isnothing(pair_alias_diagnostics.local_backend)
+
+    ibm_diagnostics = QiskitOpt.check_runtime(; local_backend=false, ibm=true, verbose=false)
+    @test !isnothing(ibm_diagnostics.ibm_runtime)
+    @test haskey(ibm_diagnostics.packages, "qiskit_ibm_runtime")
+    @test ibm_diagnostics.ibm_runtime.ok
 end
 
 @testset "Local-first execution" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -202,6 +202,7 @@ end
     @test !haskey(local_diagnostics.packages, "qiskit_ibm_runtime")
     @test !isnothing(local_diagnostics.local_backend)
     @test local_diagnostics.local_backend.ok
+    @test occursin("qiskit_ibm_runtime", local_diagnostics.local_backend.message)
     @test !python_module_loaded("qiskit_ibm_runtime")
 
     missing_error = try
@@ -230,8 +231,9 @@ end
 
     ibm_diagnostics = QiskitOpt.check_runtime(; local_backend=false, ibm=true, verbose=false)
     @test !isnothing(ibm_diagnostics.ibm_runtime)
-    @test haskey(ibm_diagnostics.packages, "qiskit_ibm_runtime")
+    @test !haskey(ibm_diagnostics.packages, "qiskit_ibm_runtime")
     @test ibm_diagnostics.ibm_runtime.ok
+    @test ibm_diagnostics.ok
 end
 
 @testset "Local-first execution" begin


### PR DESCRIPTION
Summary:
- Add structured `QiskitOpt.check_runtime` diagnostics for Julia, PythonCall, core Qiskit packages, optional IBM Runtime, and the default local backend.
- Replace eager Python/Qiskit imports with lazy module proxies that preserve `QiskitOpt.qiskit...` style access while avoiding IBM Runtime import unless requested.
- Move VQE default ansatz setup behind a callable default so package load and optimizer setup stay lazy.
- Document the diagnostics entry point. Julia reserves `local`, so the callable keyword is `local_backend`; programmatic callers can still pass `:local => true`.
- Clarify that the local backend diagnostic verifies Aer backend availability, while current QAOA/VQE local solves still use `qiskit_ibm_runtime` primitives.

Tests:
- `git diff --check`: passed.
- `QiskitOpt.check_runtime(; local_backend=true, ibm=false, verbose=false)` smoke test: passed, and `qiskit_ibm_runtime` remained unloaded.
- `QiskitOpt.check_runtime(; local_backend=false, ibm=true, verbose=true)` smoke test: passed, and IBM Runtime is reported only once.
- `/home/bernalde/.juliaup/bin/julialauncher +release --project=. -e 'using Pkg; Pkg.test()'`: passed.

Notes:
- `qiskit_ibm_runtime` is still loaded when QAOA/VQE execution needs IBM Runtime primitives, but `using QiskitOpt`, optimizer setup, and local diagnostics no longer import it eagerly.
- Fully moving local QAOA/VQE execution off IBM Runtime primitives remains follow-up work.

Refs #16
