### PR TITLE
Expose local Aer backend configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ set_attribute(
 ```
 
 You can still provide any zero-argument function that returns a Qiskit backend through `IBMFakeBackend()`.
+When `IBMFakeBackend()` is set to an explicit factory, that factory is used as-is and the Aer backend-construction attributes above do not modify it. Use `local_aer_backend_factory(...)` when you want QiskitOpt to retain the factory's Aer configuration in result metadata.
 
 ## Choosing a Local Backend
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,37 @@ set_attribute(model, VQE.Ansatz(), QiskitOpt.qiskit.circuit.library.EfficientSU2
 set_attribute(model, QAOA.NumberOfLayers(), 5)
 ```
 
+## Configuring Local Aer
+Both `QAOA.Optimizer` and `VQE.Optimizer` expose the same Aer local-simulation attributes. They apply when the optimizer builds the default local backend, and also when `IBMBackend()` is combined with `IsLocal() == true` to emulate a named IBM backend through Aer.
+
+```julia
+set_attribute(model, QAOA.AerBackendMethod(), "matrix_product_state") # or VQE.AerBackendMethod
+set_attribute(model, QAOA.AerPrecision(), "single")
+set_attribute(model, QAOA.AerMaxParallelThreads(), 8)
+set_attribute(model, QAOA.AerMPSOmpThreads(), 4)
+set_attribute(model, QAOA.AerMPSTruncationThreshold(), 1.0e-8)
+set_attribute(model, QAOA.AerMPSMaxBondDimension(), 128)
+set_attribute(model, QAOA.AerMPSSampleMeasureAlgorithm(), "mps_apply_measure")
+set_attribute(model, QAOA.AerSeedSimulator(), 73001)
+set_attribute(model, QAOA.TranspilerSeed(), 73001)
+```
+
+The returned `SampleSet` metadata records the selected backend configuration and simulator/transpiler seeds. If you need complete control, the existing backend-factory override remains available:
+
+```julia
+set_attribute(
+    model,
+    QAOA.IBMFakeBackend(),
+    QiskitOpt.local_aer_backend_factory(
+        method="statevector",
+        precision="single",
+        seed_simulator=73001,
+    ),
+)
+```
+
+You can still provide any zero-argument function that returns a Qiskit backend through `IBMFakeBackend()`.
+
 ## Choosing a Local Backend
 
 ```julia

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -2,16 +2,17 @@ module QAOA
 
 using PythonCall: pyconvert, pylist, pydict, pyint, @pyexec
 using ..QiskitOpt:
+    AerBackendConfig,
     backend_name,
+    configured_execution_backend,
     default_local_backend,
     empty_metadata,
+    preset_pass_manager,
     qiskit,
     qiskit_ibm_runtime,
-    qiskit_aer,
     quadratic_program,
     runtime_channel,
     runtime_instance,
-    runtime_service,
     sample_bits,
     scipy,
     numpy
@@ -31,6 +32,15 @@ QUBODrivers.@setup Optimizer begin
         IBMFakeBackend["ibm_fake_backend"]         = default_local_backend
         IBMBackend["ibm_backend"]::Union{String, Nothing} = nothing
         IsLocal["is_local"]::Bool                  = false
+        AerBackendMethod["aer_backend_method"]::Union{String, Nothing} = "matrix_product_state"
+        AerPrecision["aer_precision"]::Union{String, Nothing} = nothing
+        AerMaxParallelThreads["aer_max_parallel_threads"]::Union{Integer, Nothing} = nothing
+        AerMPSOmpThreads["aer_mps_omp_threads"]::Union{Integer, Nothing} = nothing
+        AerMPSTruncationThreshold["aer_mps_truncation_threshold"]::Union{Real, Nothing} = nothing
+        AerMPSMaxBondDimension["aer_mps_max_bond_dimension"]::Union{Integer, Nothing} = nothing
+        AerMPSSampleMeasureAlgorithm["aer_mps_sample_measure_algorithm"]::Union{String, Nothing} = nothing
+        AerSeedSimulator["aer_seed_simulator"]::Union{Integer, Nothing} = nothing
+        TranspilerSeed["transpiler_seed"]::Union{Integer, Nothing} = nothing
         Channel["channel"]::Union{String, Nothing} = nothing
         Instance["instance"]::Union{String, Nothing} = nothing
     end
@@ -76,6 +86,17 @@ function retrieve(
     instance        = runtime_instance(MOI.get(sampler, QAOA.Instance()))
     initial_parameters   = MOI.get(sampler, QAOA.InitialParameters())
     is_local         = MOI.get(sampler, QAOA.IsLocal())
+    aer_config = AerBackendConfig(
+        method=MOI.get(sampler, QAOA.AerBackendMethod()),
+        precision=MOI.get(sampler, QAOA.AerPrecision()),
+        max_parallel_threads=MOI.get(sampler, QAOA.AerMaxParallelThreads()),
+        mps_omp_threads=MOI.get(sampler, QAOA.AerMPSOmpThreads()),
+        mps_truncation_threshold=MOI.get(sampler, QAOA.AerMPSTruncationThreshold()),
+        mps_max_bond_dimension=MOI.get(sampler, QAOA.AerMPSMaxBondDimension()),
+        mps_sample_measure_algorithm=MOI.get(sampler, QAOA.AerMPSSampleMeasureAlgorithm()),
+        seed_simulator=MOI.get(sampler, QAOA.AerSeedSimulator()),
+        seed_transpiler=MOI.get(sampler, QAOA.TranspilerSeed()),
+    )
 
     @pyexec """
     def cost_function(params, ansatz, hamiltonian, estimator):
@@ -85,16 +106,16 @@ function retrieve(
         return energy
     """ => cost_function
 
-    backend, execution_mode = if isnothing(ibm_backend)
-        (ibm_fake_backend(), "local")
-    else
-        remote_backend = runtime_service(channel=channel, instance=instance).backend(ibm_backend)
-        if is_local
-            (qiskit_aer().AerSimulator.from_backend(remote_backend), "local")
-        else
-            (remote_backend, "cloud")
-        end
-    end
+    backend_selection = configured_execution_backend(
+        ibm_backend=ibm_backend,
+        local_backend_factory=ibm_fake_backend,
+        is_local=is_local,
+        channel=channel,
+        instance=instance,
+        aer_config=aer_config,
+    )
+    backend = backend_selection.backend
+    execution_mode = backend_selection.execution_mode
     backend_label = backend_name(backend)
 
     ising_qp = quadratic_program(sampler)
@@ -104,9 +125,10 @@ function retrieve(
         reps=num_layers,
     )
 
-    pass_manager = qiskit().transpiler.preset_passmanagers.generate_preset_pass_manager(
-        backend=backend,
+    pass_manager = preset_pass_manager(
+        backend;
         optimization_level=3,
+        seed_transpiler=aer_config.seed_transpiler,
     )
     
     ansatz_isa = pass_manager.run(ansatz)
@@ -141,7 +163,13 @@ function retrieve(
 
     callback(result, samples)
 
-    return empty_metadata("QAOA", backend_label, execution_mode)
+    return empty_metadata(
+        "QAOA",
+        backend_label,
+        execution_mode;
+        backend_config=backend_selection.config,
+        backend_config_source=backend_selection.source,
+    )
 end
 
 end # module QAOA

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -169,6 +169,7 @@ function retrieve(
         execution_mode;
         backend_config=backend_selection.config,
         backend_config_source=backend_selection.source,
+        seed_transpiler=aer_config.seed_transpiler,
     )
 end
 

--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -116,8 +116,53 @@ const qiskit_aer          = LazyPythonModule("qiskit_aer", "qiskit-aer")
 const scipy               = LazyPythonModule("scipy", "scipy")
 const numpy               = LazyPythonModule("numpy", "numpy")
 const _runtime_service_builder = Ref{Function}()
+const DEFAULT_AER_BACKEND_METHOD = "matrix_product_state"
 const _LOCAL_SOLVER_PRIMITIVES_NOTE =
     "QAOA/VQE local solves still use qiskit_ibm_runtime EstimatorV2/SamplerV2; pass ibm=true to verify those primitives."
+
+struct AerBackendConfig
+    method::Union{String,Nothing}
+    precision::Union{String,Nothing}
+    max_parallel_threads::Union{Integer,Nothing}
+    mps_omp_threads::Union{Integer,Nothing}
+    mps_truncation_threshold::Union{Real,Nothing}
+    mps_max_bond_dimension::Union{Integer,Nothing}
+    mps_sample_measure_algorithm::Union{String,Nothing}
+    seed_simulator::Union{Integer,Nothing}
+    seed_transpiler::Union{Integer,Nothing}
+end
+
+function AerBackendConfig(;
+    method::Union{AbstractString,Nothing} = DEFAULT_AER_BACKEND_METHOD,
+    precision::Union{AbstractString,Nothing} = nothing,
+    max_parallel_threads::Union{Integer,Nothing} = nothing,
+    mps_omp_threads::Union{Integer,Nothing} = nothing,
+    mps_truncation_threshold::Union{Real,Nothing} = nothing,
+    mps_max_bond_dimension::Union{Integer,Nothing} = nothing,
+    mps_sample_measure_algorithm::Union{AbstractString,Nothing} = nothing,
+    seed_simulator::Union{Integer,Nothing} = nothing,
+    seed_transpiler::Union{Integer,Nothing} = nothing,
+)
+    return AerBackendConfig(
+        nonempty_or_nothing(method),
+        nonempty_or_nothing(precision),
+        max_parallel_threads,
+        mps_omp_threads,
+        mps_truncation_threshold,
+        mps_max_bond_dimension,
+        nonempty_or_nothing(mps_sample_measure_algorithm),
+        seed_simulator,
+        seed_transpiler,
+    )
+end
+
+struct AerBackendFactory
+    config::AerBackendConfig
+end
+
+function (factory::AerBackendFactory)()
+    return local_aer_backend(factory.config)
+end
 
 function __init__()
     foreach(
@@ -373,8 +418,121 @@ function runtime_service(;
     )
 end
 
-function default_local_backend()
-    return qiskit_aer().AerSimulator(method="matrix_product_state")
+function _push_option!(options::Vector{Pair{Symbol,Any}}, name::Symbol, value)
+    isnothing(value) || push!(options, name => value)
+    return options
+end
+
+function aer_backend_options(config::AerBackendConfig)
+    options = Pair{Symbol,Any}[]
+    _push_option!(options, :method, config.method)
+    _push_option!(options, :precision, config.precision)
+    _push_option!(options, :max_parallel_threads, config.max_parallel_threads)
+    _push_option!(options, :mps_omp_threads, config.mps_omp_threads)
+    _push_option!(options, :mps_truncation_threshold, config.mps_truncation_threshold)
+    _push_option!(options, :mps_max_bond_dimension, config.mps_max_bond_dimension)
+    _push_option!(options, :mps_sample_measure_algorithm, config.mps_sample_measure_algorithm)
+    _push_option!(options, :seed_simulator, config.seed_simulator)
+
+    names = Tuple(first.(options))
+    values = Tuple(last.(options))
+    return NamedTuple{names}(values)
+end
+
+function local_aer_backend(config::AerBackendConfig = AerBackendConfig())
+    return qiskit_aer().AerSimulator(; aer_backend_options(config)...)
+end
+
+function default_local_backend(; kwargs...)
+    return local_aer_backend(AerBackendConfig(; kwargs...))
+end
+
+function local_aer_backend_factory(config::AerBackendConfig)
+    return AerBackendFactory(config)
+end
+
+function local_aer_backend_factory(; kwargs...)
+    return local_aer_backend_factory(AerBackendConfig(; kwargs...))
+end
+
+function local_aer_backend_from_backend(remote_backend, config::AerBackendConfig)
+    return qiskit_aer().AerSimulator.from_backend(
+        remote_backend;
+        aer_backend_options(config)...,
+    )
+end
+
+function configured_local_backend(local_backend_factory, config::AerBackendConfig)
+    if local_backend_factory === default_local_backend
+        return (
+            backend = local_aer_backend(config),
+            config = config,
+            source = "aer_attributes",
+        )
+    elseif local_backend_factory isa AerBackendFactory
+        return (
+            backend = local_backend_factory(),
+            config = local_backend_factory.config,
+            source = "aer_backend_factory",
+        )
+    end
+
+    return (
+        backend = local_backend_factory(),
+        config = config,
+        source = "user_backend_factory",
+    )
+end
+
+function configured_execution_backend(;
+    ibm_backend::Union{AbstractString,Nothing},
+    local_backend_factory,
+    is_local::Bool,
+    channel::AbstractString,
+    instance::Union{AbstractString,Nothing},
+    aer_config::AerBackendConfig,
+)
+    if isnothing(ibm_backend)
+        local_backend = configured_local_backend(local_backend_factory, aer_config)
+        return (
+            backend = local_backend.backend,
+            execution_mode = "local",
+            config = local_backend.config,
+            source = local_backend.source,
+        )
+    end
+
+    remote_backend = runtime_service(channel=channel, instance=instance).backend(ibm_backend)
+    if is_local
+        return (
+            backend = local_aer_backend_from_backend(remote_backend, aer_config),
+            execution_mode = "local",
+            config = aer_config,
+            source = "aer_from_backend",
+        )
+    end
+
+    return (
+        backend = remote_backend,
+        execution_mode = "cloud",
+        config = aer_config,
+        source = "cloud_backend",
+    )
+end
+
+function preset_pass_manager(backend; optimization_level::Integer = 3, seed_transpiler = nothing)
+    if isnothing(seed_transpiler)
+        return qiskit().transpiler.preset_passmanagers.generate_preset_pass_manager(
+            backend=backend,
+            optimization_level=optimization_level,
+        )
+    end
+
+    return qiskit().transpiler.preset_passmanagers.generate_preset_pass_manager(
+        backend=backend,
+        optimization_level=optimization_level,
+        seed_transpiler=seed_transpiler,
+    )
 end
 
 function backend_name(backend)
@@ -390,14 +548,48 @@ function sample_bits(key)
     return reverse(Int[(digit == '1') for digit in bitstring])
 end
 
-function empty_metadata(algorithm::AbstractString, backend::AbstractString, execution_mode::AbstractString)
+function aer_backend_metadata(config::AerBackendConfig, source::AbstractString)
     return Dict{String,Any}(
+        "source" => String(source),
+        "method" => config.method,
+        "precision" => config.precision,
+        "max_parallel_threads" => config.max_parallel_threads,
+        "mps_omp_threads" => config.mps_omp_threads,
+        "mps_truncation_threshold" => config.mps_truncation_threshold,
+        "mps_max_bond_dimension" => config.mps_max_bond_dimension,
+        "mps_sample_measure_algorithm" => config.mps_sample_measure_algorithm,
+    )
+end
+
+function seed_metadata(config::AerBackendConfig)
+    return Dict{String,Any}(
+        "simulator" => config.seed_simulator,
+        "transpiler" => config.seed_transpiler,
+    )
+end
+
+function empty_metadata(
+    algorithm::AbstractString,
+    backend::AbstractString,
+    execution_mode::AbstractString;
+    backend_config::Union{AerBackendConfig,Nothing} = nothing,
+    backend_config_source::Union{AbstractString,Nothing} = nothing,
+)
+    metadata = Dict{String,Any}(
         "origin" => "$(algorithm) @ $(backend)",
         "backend" => backend,
         "execution_mode" => execution_mode,
         "time" => Dict{String,Any}(),
         "evals" => Float64[],
     )
+
+    if !isnothing(backend_config)
+        source = isnothing(backend_config_source) ? "unknown" : backend_config_source
+        metadata["backend_configuration"] = aer_backend_metadata(backend_config, source)
+        metadata["seeds"] = seed_metadata(backend_config)
+    end
+
+    return metadata
 end
 
 function quadratic_program(sampler::QUBODrivers.AbstractSampler{T}) where {T}

--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -479,7 +479,7 @@ function configured_local_backend(local_backend_factory, config::AerBackendConfi
 
     return (
         backend = local_backend_factory(),
-        config = config,
+        config = nothing,
         source = "user_backend_factory",
     )
 end
@@ -515,7 +515,7 @@ function configured_execution_backend(;
     return (
         backend = remote_backend,
         execution_mode = "cloud",
-        config = aer_config,
+        config = nothing,
         source = "cloud_backend",
     )
 end
@@ -561,10 +561,13 @@ function aer_backend_metadata(config::AerBackendConfig, source::AbstractString)
     )
 end
 
-function seed_metadata(config::AerBackendConfig)
+function seed_metadata(;
+    seed_simulator = nothing,
+    seed_transpiler = nothing,
+)
     return Dict{String,Any}(
-        "simulator" => config.seed_simulator,
-        "transpiler" => config.seed_transpiler,
+        "simulator" => seed_simulator,
+        "transpiler" => seed_transpiler,
     )
 end
 
@@ -574,6 +577,7 @@ function empty_metadata(
     execution_mode::AbstractString;
     backend_config::Union{AerBackendConfig,Nothing} = nothing,
     backend_config_source::Union{AbstractString,Nothing} = nothing,
+    seed_transpiler = nothing,
 )
     metadata = Dict{String,Any}(
         "origin" => "$(algorithm) @ $(backend)",
@@ -583,10 +587,21 @@ function empty_metadata(
         "evals" => Float64[],
     )
 
-    if !isnothing(backend_config)
+    if !isnothing(backend_config) || !isnothing(backend_config_source)
         source = isnothing(backend_config_source) ? "unknown" : backend_config_source
-        metadata["backend_configuration"] = aer_backend_metadata(backend_config, source)
-        metadata["seeds"] = seed_metadata(backend_config)
+        metadata["backend_configuration"] = if isnothing(backend_config)
+            Dict{String,Any}("source" => String(source))
+        else
+            aer_backend_metadata(backend_config, source)
+        end
+    end
+
+    if !isnothing(backend_config) || !isnothing(seed_transpiler)
+        seed_simulator = isnothing(backend_config) ? nothing : backend_config.seed_simulator
+        metadata["seeds"] = seed_metadata(
+            seed_simulator=seed_simulator,
+            seed_transpiler=seed_transpiler,
+        )
     end
 
     return metadata

--- a/src/VQE.jl
+++ b/src/VQE.jl
@@ -2,16 +2,17 @@ module VQE
 
 using PythonCall: pyconvert, pylist, pydict, pyint, @pyexec
 using ..QiskitOpt:
+    AerBackendConfig,
     backend_name,
+    configured_execution_backend,
     default_local_backend,
     empty_metadata,
+    preset_pass_manager,
     qiskit,
     qiskit_ibm_runtime,
-    qiskit_aer,
     quadratic_program,
     runtime_channel,
     runtime_instance,
-    runtime_service,
     sample_bits,
     scipy,
     numpy
@@ -34,6 +35,15 @@ QUBODrivers.@setup Optimizer begin
         IBMFakeBackend["ibm_fake_backend"]         = default_local_backend
         IBMBackend["ibm_backend"]::Union{String, Nothing} = nothing
         IsLocal["is_local"]::Bool                  = false
+        AerBackendMethod["aer_backend_method"]::Union{String, Nothing} = "matrix_product_state"
+        AerPrecision["aer_precision"]::Union{String, Nothing} = nothing
+        AerMaxParallelThreads["aer_max_parallel_threads"]::Union{Integer, Nothing} = nothing
+        AerMPSOmpThreads["aer_mps_omp_threads"]::Union{Integer, Nothing} = nothing
+        AerMPSTruncationThreshold["aer_mps_truncation_threshold"]::Union{Real, Nothing} = nothing
+        AerMPSMaxBondDimension["aer_mps_max_bond_dimension"]::Union{Integer, Nothing} = nothing
+        AerMPSSampleMeasureAlgorithm["aer_mps_sample_measure_algorithm"]::Union{String, Nothing} = nothing
+        AerSeedSimulator["aer_seed_simulator"]::Union{Integer, Nothing} = nothing
+        TranspilerSeed["transpiler_seed"]::Union{Integer, Nothing} = nothing
         Channel["channel"]::Union{String, Nothing} = nothing
         Instance["instance"]::Union{String, Nothing} = nothing
         Ansatz["ansatz"]                           = default_ansatz
@@ -80,6 +90,17 @@ function retrieve(
     instance        = runtime_instance(MOI.get(sampler, VQE.Instance()))
     initial_parameters   = MOI.get(sampler, VQE.InitialParameters())
     is_local         = MOI.get(sampler, VQE.IsLocal())
+    aer_config = AerBackendConfig(
+        method=MOI.get(sampler, VQE.AerBackendMethod()),
+        precision=MOI.get(sampler, VQE.AerPrecision()),
+        max_parallel_threads=MOI.get(sampler, VQE.AerMaxParallelThreads()),
+        mps_omp_threads=MOI.get(sampler, VQE.AerMPSOmpThreads()),
+        mps_truncation_threshold=MOI.get(sampler, VQE.AerMPSTruncationThreshold()),
+        mps_max_bond_dimension=MOI.get(sampler, VQE.AerMPSMaxBondDimension()),
+        mps_sample_measure_algorithm=MOI.get(sampler, VQE.AerMPSSampleMeasureAlgorithm()),
+        seed_simulator=MOI.get(sampler, VQE.AerSeedSimulator()),
+        seed_transpiler=MOI.get(sampler, VQE.TranspilerSeed()),
+    )
 
     @pyexec """
     def cost_function(params, ansatz, hamiltonian, estimator):
@@ -89,16 +110,16 @@ function retrieve(
         return energy
     """ => cost_function
 
-    backend, execution_mode = if isnothing(ibm_backend)
-        (ibm_fake_backend(), "local")
-    else
-        remote_backend = runtime_service(channel=channel, instance=instance).backend(ibm_backend)
-        if is_local
-            (qiskit_aer().AerSimulator.from_backend(remote_backend), "local")
-        else
-            (remote_backend, "cloud")
-        end
-    end
+    backend_selection = configured_execution_backend(
+        ibm_backend=ibm_backend,
+        local_backend_factory=ibm_fake_backend,
+        is_local=is_local,
+        channel=channel,
+        instance=instance,
+        aer_config=aer_config,
+    )
+    backend = backend_selection.backend
+    execution_mode = backend_selection.execution_mode
     backend_label = backend_name(backend)
 
     ising_qp = quadratic_program(sampler)
@@ -106,9 +127,10 @@ function retrieve(
     num_qubits = pyconvert(Int, ising_hamiltonian.num_qubits)
     ansatz = ansatz_instance(num_qubits=num_qubits)
 
-    pass_manager = qiskit().transpiler.preset_passmanagers.generate_preset_pass_manager(
-        backend=backend,
+    pass_manager = preset_pass_manager(
+        backend;
         optimization_level=3,
+        seed_transpiler=aer_config.seed_transpiler,
     )
     
     ansatz_isa = pass_manager.run(ansatz)
@@ -143,7 +165,13 @@ function retrieve(
 
     callback(result, samples)
 
-    return empty_metadata("VQE", backend_label, execution_mode)
+    return empty_metadata(
+        "VQE",
+        backend_label,
+        execution_mode;
+        backend_config=backend_selection.config,
+        backend_config_source=backend_selection.source,
+    )
 end
 
 end # module VQE

--- a/src/VQE.jl
+++ b/src/VQE.jl
@@ -171,6 +171,7 @@ function retrieve(
         execution_mode;
         backend_config=backend_selection.config,
         backend_config_source=backend_selection.source,
+        seed_transpiler=aer_config.seed_transpiler,
     )
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 using QiskitOpt
-using QiskitOpt: QAOA, QUBODrivers, VQE
+using QiskitOpt: QAOA, QUBODrivers, QUBOTools, VQE
 
 MOI = QUBODrivers.MOI
 
@@ -182,6 +182,42 @@ function solve_locally_without_runtime_service(
     end
 end
 
+function sample_locally_without_runtime_service(
+    optimizer_factory,
+    optimizer_module,
+    configure!::Function = (_, _) -> nothing;
+    max_iterations=1,
+    number_of_reads=16,
+)
+    withenv(
+        "QISKIT_IBM_TOKEN" => nothing,
+        "QISKIT_IBM_INSTANCE" => nothing,
+        "QISKIT_IBM_CHANNEL" => nothing,
+        "IBMQ_API_TOKEN" => nothing,
+        "IBMQ_INSTANCE" => nothing,
+    ) do
+        previous_builder = QiskitOpt._runtime_service_builder[]
+        QiskitOpt._runtime_service_builder[] = (; kwargs...) -> error(
+            "runtime service should not be created for local execution",
+        )
+
+        try
+            model, _ = build_model(optimizer_factory)
+            configure_solver!(
+                model,
+                optimizer_module;
+                max_iterations=max_iterations,
+                number_of_reads=number_of_reads,
+            )
+            configure!(model, optimizer_module)
+            MOI.optimize!(model)
+            return QUBOTools.solution(MOI.get(model, MOI.RawSolver()))
+        finally
+            QiskitOpt._runtime_service_builder[] = previous_builder
+        end
+    end
+end
+
 function run_qubodrivers_suite(optimizer_module)
     QUBODrivers.test(optimizer_module.Optimizer) do model
         MOI.set(model, optimizer_module.MaximumIterations(), 5)
@@ -239,6 +275,84 @@ end
 @testset "Local-first execution" begin
     solve_locally_without_runtime_service(QAOA.Optimizer, QAOA)
     solve_locally_without_runtime_service(VQE.Optimizer, VQE)
+end
+
+@testset "Aer backend configuration helpers" begin
+    default_config = QiskitOpt.AerBackendConfig()
+    @test QiskitOpt.aer_backend_options(default_config) == (method="matrix_product_state",)
+
+    custom_config = QiskitOpt.AerBackendConfig(
+        method="statevector",
+        precision="single",
+        max_parallel_threads=2,
+        mps_omp_threads=1,
+        mps_truncation_threshold=1.0e-6,
+        mps_max_bond_dimension=32,
+        mps_sample_measure_algorithm="mps_apply_measure",
+        seed_simulator=1234,
+        seed_transpiler=5678,
+    )
+    options = QiskitOpt.aer_backend_options(custom_config)
+    @test options.method == "statevector"
+    @test options.precision == "single"
+    @test options.max_parallel_threads == 2
+    @test options.mps_omp_threads == 1
+    @test options.mps_truncation_threshold == 1.0e-6
+    @test options.mps_max_bond_dimension == 32
+    @test options.mps_sample_measure_algorithm == "mps_apply_measure"
+    @test options.seed_simulator == 1234
+    @test !(:seed_transpiler in keys(options))
+
+    metadata = QiskitOpt.empty_metadata(
+        "QAOA",
+        "aer_simulator",
+        "local";
+        backend_config=custom_config,
+        backend_config_source="aer_attributes",
+    )
+    @test metadata["backend_configuration"]["source"] == "aer_attributes"
+    @test metadata["backend_configuration"]["method"] == "statevector"
+    @test metadata["backend_configuration"]["precision"] == "single"
+    @test metadata["seeds"]["simulator"] == 1234
+    @test metadata["seeds"]["transpiler"] == 5678
+
+    factory = QiskitOpt.local_aer_backend_factory(custom_config)
+    @test factory.config.seed_simulator == 1234
+    @test QiskitOpt.local_aer_backend_factory().config.method == "matrix_product_state"
+
+    sentinel_backend = Ref(:backend)
+    selected = QiskitOpt.configured_local_backend(() -> sentinel_backend[], default_config)
+    @test selected.backend === :backend
+    @test selected.source == "user_backend_factory"
+end
+
+@testset "Aer backend configuration is recorded in SampleSet metadata" begin
+    for (optimizer_factory, optimizer_module, algorithm) in (
+        (QAOA.Optimizer, QAOA, "QAOA"),
+        (VQE.Optimizer, VQE, "VQE"),
+    )
+        sampleset = sample_locally_without_runtime_service(
+            optimizer_factory,
+            optimizer_module,
+            (model, module_) -> begin
+                MOI.set(model, module_.AerPrecision(), "single")
+                MOI.set(model, module_.AerMaxParallelThreads(), 1)
+                MOI.set(model, module_.AerSeedSimulator(), 1234)
+                MOI.set(model, module_.TranspilerSeed(), 5678)
+            end;
+            max_iterations=1,
+            number_of_reads=16,
+        )
+        metadata = QUBOTools.metadata(sampleset)
+        @test startswith(metadata["origin"], "$(algorithm) @ ")
+        @test metadata["execution_mode"] == "local"
+        @test metadata["backend_configuration"]["source"] == "aer_attributes"
+        @test metadata["backend_configuration"]["method"] == "matrix_product_state"
+        @test metadata["backend_configuration"]["precision"] == "single"
+        @test metadata["backend_configuration"]["max_parallel_threads"] == 1
+        @test metadata["seeds"]["simulator"] == 1234
+        @test metadata["seeds"]["transpiler"] == 5678
+    end
 end
 
 @testset "Max-sense objective reporting stays consistent" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -309,12 +309,27 @@ end
         "local";
         backend_config=custom_config,
         backend_config_source="aer_attributes",
+        seed_transpiler=5678,
     )
     @test metadata["backend_configuration"]["source"] == "aer_attributes"
     @test metadata["backend_configuration"]["method"] == "statevector"
     @test metadata["backend_configuration"]["precision"] == "single"
     @test metadata["seeds"]["simulator"] == 1234
     @test metadata["seeds"]["transpiler"] == 5678
+
+    opaque_metadata = QiskitOpt.empty_metadata(
+        "QAOA",
+        "custom_backend",
+        "local";
+        backend_config_source="user_backend_factory",
+        seed_transpiler=5678,
+    )
+    @test opaque_metadata["backend_configuration"] == Dict{String,Any}(
+        "source" => "user_backend_factory",
+    )
+    @test !haskey(opaque_metadata["backend_configuration"], "method")
+    @test opaque_metadata["seeds"]["simulator"] === nothing
+    @test opaque_metadata["seeds"]["transpiler"] == 5678
 
     factory = QiskitOpt.local_aer_backend_factory(custom_config)
     @test factory.config.seed_simulator == 1234
@@ -323,6 +338,7 @@ end
     sentinel_backend = Ref(:backend)
     selected = QiskitOpt.configured_local_backend(() -> sentinel_backend[], default_config)
     @test selected.backend === :backend
+    @test selected.config === nothing
     @test selected.source == "user_backend_factory"
 end
 


### PR DESCRIPTION
## Summary

- Add shared `AerBackendConfig` and backend construction helpers for local Aer options.
- Expose matching QAOA and VQE MOI attributes for Aer method, precision, threading, MPS controls, simulator seed, and transpiler seed.
- Record backend configuration and seed metadata on returned `SampleSet`s.
- Preserve backend factory override support through `IBMFakeBackend()` and document the new local Aer configuration path.

## Tests

- `/home/bernalde/.juliaup/bin/julialauncher +release --project=. -e 'using Pkg; Pkg.test()'`
- `git diff --check`

Closes #17
