### PR TITLE
Add initial parameter helpers and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ qaoa_start = QiskitOpt.QAOA.fixed_angle_initial_parameters(
     number_of_layers=2,
     gamma_sign=-1,
 )
+qaoa_guarantee = QiskitOpt.QAOA.fixed_angle_guarantee(number_of_layers=2)
 set_attribute(model, QiskitOpt.QAOA.NumberOfLayers(), 2)
 set_attribute(model, QiskitOpt.QAOA.InitialParameters(), qaoa_start)
 set_attribute(model, QiskitOpt.QAOA.InitialParameterSource(), QiskitOpt.QAOA.FIXED_ANGLE_SOURCE)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,39 @@ set_attribute(model, VQE.Ansatz(), QiskitOpt.qiskit.circuit.library.EfficientSU2
 set_attribute(model, QAOA.NumberOfLayers(), 5)
 ```
 
+## Initial Parameters
+Both optimizers expose helpers for reproducible initial parameters and validate
+the vector length before Qiskit execution starts.
+
+```julia
+# QAOA parameter order is beta angles followed by gamma angles.
+QiskitOpt.QAOA.parameter_names(36; number_of_layers=2)
+
+qaoa_start = QiskitOpt.QAOA.fixed_angle_initial_parameters(
+    number_of_layers=2,
+    gamma_sign=-1,
+)
+set_attribute(model, QiskitOpt.QAOA.NumberOfLayers(), 2)
+set_attribute(model, QiskitOpt.QAOA.InitialParameters(), qaoa_start)
+set_attribute(model, QiskitOpt.QAOA.InitialParameterSource(), QiskitOpt.QAOA.FIXED_ANGLE_SOURCE)
+```
+
+```julia
+# VQE parameter order comes from the selected Qiskit ansatz.
+vqe_names = QiskitOpt.VQE.parameter_names(n_variables=36)
+vqe_start = QiskitOpt.VQE.random_initial_parameters(n_variables=36, seed=73001)
+set_attribute(model, QiskitOpt.VQE.InitialParameters(), vqe_start)
+set_attribute(model, QiskitOpt.VQE.InitialParameterSource(), "random_seed_73001")
+```
+
+Returned `SampleSet` metadata records the source, parameter names, and actual
+initial vector under `metadata["initial_parameters"]`. Disable this with
+`RecordInitialParameters()` when you do not want parameters retained in metadata:
+
+```julia
+set_attribute(model, QiskitOpt.QAOA.RecordInitialParameters(), false)
+```
+
 ## Configuring Local Aer
 Both `QAOA.Optimizer` and `VQE.Optimizer` expose the same Aer local-simulation attributes. They apply when the optimizer builds the default local backend, and also when `IBMBackend()` is combined with `IsLocal() == true` to emulate a named IBM backend through Aer.
 

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -8,19 +8,40 @@ using ..QiskitOpt:
     default_local_backend,
     empty_metadata,
     preset_pass_manager,
+    qiskit_parameter_names,
     qiskit,
     qiskit_ibm_runtime,
     quadratic_program,
+    random_unit_values,
     runtime_channel,
     runtime_instance,
     sample_bits,
     scipy,
-    numpy
+    numpy,
+    validate_initial_parameters
 
 using QUBO
 MOI = QUBODrivers.MOI
 Sample = QUBODrivers.Sample
 SampleSet = QUBODrivers.SampleSet
+
+const FIXED_ANGLE_SOURCE = "Wurtz-Lykov 3-regular tree fixed-angle table; arXiv:2107.00677"
+
+const _WURTZ_LYKOV_3REGULAR_TREE_ANGLES = Dict(
+    1 => (gamma = [0.616], beta = [0.393], guarantee = 0.6925),
+    2 => (gamma = [0.488, 0.898], beta = [0.555, 0.293], guarantee = 0.7559),
+    3 => (gamma = [0.422, 0.798, 0.937], beta = [0.609, 0.459, 0.235], guarantee = 0.7924),
+    4 => (
+        gamma = [0.409, 0.781, 0.988, 1.156],
+        beta = [0.600, 0.434, 0.297, 0.159],
+        guarantee = 0.8169,
+    ),
+    5 => (
+        gamma = [0.360, 0.707, 0.823, 1.005, 1.154],
+        beta = [0.632, 0.523, 0.390, 0.275, 0.149],
+        guarantee = 0.8364,
+    ),
+)
 
 QUBODrivers.@setup Optimizer begin
     name    = "QAOA @ IBM Quantum"
@@ -29,6 +50,8 @@ QUBODrivers.@setup Optimizer begin
         NumberOfReads["num_reads"]::Integer        = 100
         NumberOfLayers["num_layers"]::Integer      = 1
         InitialParameters["initial_parameters"]::Union{Vector{Float64}, Nothing} = nothing 
+        InitialParameterSource["initial_parameter_source"]::Union{String, Nothing} = nothing
+        RecordInitialParameters["record_initial_parameters"]::Bool = true
         IBMFakeBackend["ibm_fake_backend"]         = default_local_backend
         IBMBackend["ibm_backend"]::Union{String, Nothing} = nothing
         IsLocal["is_local"]::Bool                  = false
@@ -44,6 +67,105 @@ QUBODrivers.@setup Optimizer begin
         Channel["channel"]::Union{String, Nothing} = nothing
         Instance["instance"]::Union{String, Nothing} = nothing
     end
+end
+
+function _check_number_of_layers(number_of_layers::Integer)
+    number_of_layers >= 1 || throw(ArgumentError("number_of_layers must be at least 1"))
+    return Int(number_of_layers)
+end
+
+function _check_n_variables(n_variables::Integer)
+    n_variables >= 1 || throw(ArgumentError("n_variables must be at least 1"))
+    return Int(n_variables)
+end
+
+function _parameter_names(number_of_layers::Integer)
+    p = _check_number_of_layers(number_of_layers)
+    beta_names = ["β[$(layer)]" for layer in 0:(p - 1)]
+    gamma_names = ["γ[$(layer)]" for layer in 0:(p - 1)]
+    return vcat(beta_names, gamma_names)
+end
+
+"""
+    QAOA.parameter_names([problem_or_nqubits]; number_of_layers)
+
+Return the Qiskit list-binding order for `QAOAAnsatz` parameters.
+
+# Examples
+```julia
+julia> QAOA.parameter_names(36; number_of_layers=2)
+4-element Vector{String}:
+ "β[0]"
+ "β[1]"
+ "γ[0]"
+ "γ[1]"
+```
+"""
+function parameter_names(; number_of_layers::Integer)
+    return _parameter_names(number_of_layers)
+end
+
+function parameter_names(n_variables::Integer; number_of_layers::Integer)
+    _check_n_variables(n_variables)
+    return _parameter_names(number_of_layers)
+end
+
+function parameter_names(sampler::QUBODrivers.AbstractSampler; number_of_layers::Integer = MOI.get(sampler, QAOA.NumberOfLayers()))
+    ising_hamiltonian = quadratic_program(sampler)[0]
+    return parameter_names(ising_hamiltonian; number_of_layers=number_of_layers)
+end
+
+function parameter_names(cost_operator; number_of_layers::Integer)
+    p = _check_number_of_layers(number_of_layers)
+    ansatz = qiskit().circuit.library.QAOAAnsatz(cost_operator, reps=p)
+    return qiskit_parameter_names(ansatz)
+end
+
+"""
+    QAOA.parameter_count([problem_or_nqubits]; number_of_layers)
+
+Return the expected number of QAOA initial parameters.
+"""
+function parameter_count(; number_of_layers::Integer)
+    return length(parameter_names(; number_of_layers=number_of_layers))
+end
+
+function parameter_count(problem_or_nqubits; number_of_layers::Integer)
+    return length(parameter_names(problem_or_nqubits; number_of_layers=number_of_layers))
+end
+
+"""
+    QAOA.random_initial_parameters(; number_of_layers, seed=nothing, rng=nothing)
+
+Return random QAOA angles in Qiskit parameter order. Passing `seed` makes
+the returned vector reproducible.
+"""
+function random_initial_parameters(; number_of_layers::Integer, seed = nothing, rng = nothing)
+    count = parameter_count(; number_of_layers=number_of_layers)
+    return 2π .* random_unit_values(count; seed=seed, rng=rng)
+end
+
+"""
+    QAOA.fixed_angle_initial_parameters(; number_of_layers, family=:wurtz_lykov_3regular_tree, gamma_sign=-1)
+
+Return fixed-angle QAOA warm-start parameters in Qiskit's list-binding order.
+The built-in Wurtz-Lykov 3-regular tree table supports depths 1 through 5.
+"""
+function fixed_angle_initial_parameters(;
+    number_of_layers::Integer,
+    family::Symbol = :wurtz_lykov_3regular_tree,
+    gamma_sign::Real = -1,
+)
+    p = _check_number_of_layers(number_of_layers)
+    if family != :wurtz_lykov_3regular_tree
+        throw(ArgumentError("unsupported fixed-angle family: $(family)"))
+    end
+    if !haskey(_WURTZ_LYKOV_3REGULAR_TREE_ANGLES, p)
+        throw(ArgumentError("fixed-angle family $(family) supports number_of_layers values 1 through 5"))
+    end
+
+    angles = _WURTZ_LYKOV_3REGULAR_TREE_ANGLES[p]
+    return Float64[v for v in vcat(angles.beta, gamma_sign .* angles.gamma)]
 end
 
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
@@ -85,6 +207,8 @@ function retrieve(
     channel         = runtime_channel(MOI.get(sampler, QAOA.Channel()))
     instance        = runtime_instance(MOI.get(sampler, QAOA.Instance()))
     initial_parameters   = MOI.get(sampler, QAOA.InitialParameters())
+    initial_parameter_source = MOI.get(sampler, QAOA.InitialParameterSource())
+    record_initial_parameters = MOI.get(sampler, QAOA.RecordInitialParameters())
     is_local         = MOI.get(sampler, QAOA.IsLocal())
     aer_config = AerBackendConfig(
         method=MOI.get(sampler, QAOA.AerBackendMethod()),
@@ -97,6 +221,27 @@ function retrieve(
         seed_simulator=MOI.get(sampler, QAOA.AerSeedSimulator()),
         seed_transpiler=MOI.get(sampler, QAOA.TranspilerSeed()),
     )
+
+    ising_qp = quadratic_program(sampler)
+    ising_hamiltonian = ising_qp[0]
+    ansatz = qiskit().circuit.library.QAOAAnsatz(
+        ising_hamiltonian,
+        reps=num_layers,
+    )
+    parameter_names = qiskit_parameter_names(ansatz)
+    expected_parameter_count = length(parameter_names)
+
+    initial_parameter_values = if isnothing(initial_parameters)
+        zeros(expected_parameter_count)
+    else
+        validate_initial_parameters(initial_parameters, expected_parameter_count, "QAOA")
+        Float64.(initial_parameters)
+    end
+    initial_parameter_source = if isnothing(initial_parameter_source)
+        isnothing(initial_parameters) ? "default_zero" : "user"
+    else
+        initial_parameter_source
+    end
 
     @pyexec """
     def cost_function(params, ansatz, hamiltonian, estimator):
@@ -118,13 +263,6 @@ function retrieve(
     execution_mode = backend_selection.execution_mode
     backend_label = backend_name(backend)
 
-    ising_qp = quadratic_program(sampler)
-    ising_hamiltonian = ising_qp[0]
-    ansatz = qiskit().circuit.library.QAOAAnsatz(
-        ising_hamiltonian,
-        reps=num_layers,
-    )
-
     pass_manager = preset_pass_manager(
         backend;
         optimization_level=3,
@@ -135,11 +273,7 @@ function retrieve(
     ising_hamiltonian = ising_hamiltonian.apply_layout(layout=ansatz_isa.layout)
 
 
-    if isnothing(initial_parameters)
-        initial_parameters = numpy().zeros(pyint(pyconvert(Int, ansatz_isa.num_parameters)))
-    else
-        initial_parameters = numpy().array(initial_parameters)
-    end
+    initial_parameters = numpy().array(initial_parameter_values)
 
     estimator = qiskit_ibm_runtime().EstimatorV2(mode=backend)
     estimator.options.default_shots = num_reads
@@ -170,6 +304,9 @@ function retrieve(
         backend_config=backend_selection.config,
         backend_config_source=backend_selection.source,
         seed_transpiler=aer_config.seed_transpiler,
+        initial_parameters=record_initial_parameters ? initial_parameter_values : nothing,
+        initial_parameter_names=record_initial_parameters ? parameter_names : nothing,
+        initial_parameter_source=record_initial_parameters ? initial_parameter_source : nothing,
     )
 end
 

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -86,6 +86,18 @@ function _parameter_names(number_of_layers::Integer)
     return vcat(beta_names, gamma_names)
 end
 
+function _fixed_angle_record(number_of_layers::Integer, family::Symbol)
+    p = _check_number_of_layers(number_of_layers)
+    if family != :wurtz_lykov_3regular_tree
+        throw(ArgumentError("unsupported fixed-angle family: $(family)"))
+    end
+    if !haskey(_WURTZ_LYKOV_3REGULAR_TREE_ANGLES, p)
+        throw(ArgumentError("fixed-angle family $(family) supports number_of_layers values 1 through 5"))
+    end
+
+    return _WURTZ_LYKOV_3REGULAR_TREE_ANGLES[p]
+end
+
 """
     QAOA.parameter_names([problem_or_nqubits]; number_of_layers)
 
@@ -146,6 +158,19 @@ function random_initial_parameters(; number_of_layers::Integer, seed = nothing, 
 end
 
 """
+    QAOA.fixed_angle_guarantee(; number_of_layers, family=:wurtz_lykov_3regular_tree)
+
+Return the approximation-ratio guarantee reported with the built-in fixed-angle
+table.
+"""
+function fixed_angle_guarantee(;
+    number_of_layers::Integer,
+    family::Symbol = :wurtz_lykov_3regular_tree,
+)
+    return Float64(_fixed_angle_record(number_of_layers, family).guarantee)
+end
+
+"""
     QAOA.fixed_angle_initial_parameters(; number_of_layers, family=:wurtz_lykov_3regular_tree, gamma_sign=-1)
 
 Return fixed-angle QAOA warm-start parameters in Qiskit's list-binding order.
@@ -156,15 +181,7 @@ function fixed_angle_initial_parameters(;
     family::Symbol = :wurtz_lykov_3regular_tree,
     gamma_sign::Real = -1,
 )
-    p = _check_number_of_layers(number_of_layers)
-    if family != :wurtz_lykov_3regular_tree
-        throw(ArgumentError("unsupported fixed-angle family: $(family)"))
-    end
-    if !haskey(_WURTZ_LYKOV_3REGULAR_TREE_ANGLES, p)
-        throw(ArgumentError("fixed-angle family $(family) supports number_of_layers values 1 through 5"))
-    end
-
-    angles = _WURTZ_LYKOV_3REGULAR_TREE_ANGLES[p]
+    angles = _fixed_angle_record(number_of_layers, family)
     return Float64[v for v in vcat(angles.beta, gamma_sign .* angles.gamma)]
 end
 

--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -571,6 +571,86 @@ function seed_metadata(;
     )
 end
 
+function _seed_state(seed::Integer)
+    modulus = BigInt(typemax(UInt64)) + 1
+    return UInt64(mod(BigInt(seed), modulus))
+end
+
+function _splitmix64_next(state::UInt64)
+    state += 0x9e3779b97f4a7c15
+    value = state
+    value = xor(value, value >> 30) * 0xbf58476d1ce4e5b9
+    value = xor(value, value >> 27) * 0x94d049bb133111eb
+    return state, xor(value, value >> 31)
+end
+
+function _unit_float(value::UInt64)
+    return Float64(value >> 11) * 0x1.0p-53
+end
+
+function _seeded_unit_values(seed::Integer, count::Integer)
+    state = _seed_state(seed)
+    values = Vector{Float64}(undef, count)
+    for index in eachindex(values)
+        state, value = _splitmix64_next(state)
+        values[index] = _unit_float(value)
+    end
+    return values
+end
+
+function random_unit_values(count::Integer; seed = nothing, rng = nothing)
+    count >= 0 || throw(ArgumentError("count must be nonnegative"))
+    if !isnothing(seed) && !isnothing(rng)
+        throw(ArgumentError("provide either seed or rng, not both"))
+    end
+
+    if !isnothing(rng)
+        return rand(rng, Float64, count)
+    elseif !isnothing(seed)
+        seed isa Integer || throw(ArgumentError("seed must be an integer"))
+        return _seeded_unit_values(seed, count)
+    end
+
+    return rand(Float64, count)
+end
+
+function qiskit_parameter_names(circuit)
+    return String[
+        PythonCall.pyconvert(String, PythonCall.pystr(parameter))
+        for parameter in circuit.parameters
+    ]
+end
+
+function validate_initial_parameters(
+    initial_parameters::AbstractVector,
+    expected_count::Integer,
+    algorithm::AbstractString,
+)
+    actual_count = length(initial_parameters)
+    if actual_count != expected_count
+        throw(
+            ArgumentError(
+                "$(algorithm) InitialParameters length $(actual_count) does not match " *
+                "the expected Qiskit ansatz parameter count $(expected_count)",
+            ),
+        )
+    end
+
+    return nothing
+end
+
+function initial_parameter_metadata(
+    source::AbstractString,
+    values::AbstractVector,
+    names::AbstractVector{<:AbstractString},
+)
+    return Dict{String,Any}(
+        "source" => String(source),
+        "parameter_names" => String.(names),
+        "values" => Float64.(values),
+    )
+end
+
 function empty_metadata(
     algorithm::AbstractString,
     backend::AbstractString,
@@ -578,6 +658,9 @@ function empty_metadata(
     backend_config::Union{AerBackendConfig,Nothing} = nothing,
     backend_config_source::Union{AbstractString,Nothing} = nothing,
     seed_transpiler = nothing,
+    initial_parameters::Union{AbstractVector,Nothing} = nothing,
+    initial_parameter_names::Union{AbstractVector{<:AbstractString},Nothing} = nothing,
+    initial_parameter_source::Union{AbstractString,Nothing} = nothing,
 )
     metadata = Dict{String,Any}(
         "origin" => "$(algorithm) @ $(backend)",
@@ -602,6 +685,12 @@ function empty_metadata(
             seed_simulator=seed_simulator,
             seed_transpiler=seed_transpiler,
         )
+    end
+
+    if !isnothing(initial_parameters)
+        source = isnothing(initial_parameter_source) ? "unknown" : initial_parameter_source
+        names = isnothing(initial_parameter_names) ? String[] : initial_parameter_names
+        metadata["initial_parameters"] = initial_parameter_metadata(source, initial_parameters, names)
     end
 
     return metadata

--- a/src/VQE.jl
+++ b/src/VQE.jl
@@ -8,14 +8,17 @@ using ..QiskitOpt:
     default_local_backend,
     empty_metadata,
     preset_pass_manager,
+    qiskit_parameter_names,
     qiskit,
     qiskit_ibm_runtime,
     quadratic_program,
+    random_unit_values,
     runtime_channel,
     runtime_instance,
     sample_bits,
     scipy,
-    numpy
+    numpy,
+    validate_initial_parameters
 
 using QUBO
 MOI = QUBODrivers.MOI
@@ -32,6 +35,8 @@ QUBODrivers.@setup Optimizer begin
         MaximumIterations["max_iter"]::Integer     = 15
         NumberOfReads["num_reads"]::Integer        = 100
         InitialParameters["initial_parameters"]::Union{Vector{Float64}, Nothing} = nothing 
+        InitialParameterSource["initial_parameter_source"]::Union{String, Nothing} = nothing
+        RecordInitialParameters["record_initial_parameters"]::Bool = true
         IBMFakeBackend["ibm_fake_backend"]         = default_local_backend
         IBMBackend["ibm_backend"]::Union{String, Nothing} = nothing
         IsLocal["is_local"]::Bool                  = false
@@ -48,6 +53,69 @@ QUBODrivers.@setup Optimizer begin
         Instance["instance"]::Union{String, Nothing} = nothing
         Ansatz["ansatz"]                           = default_ansatz
     end
+end
+
+function _check_n_variables(n_variables::Integer)
+    n_variables >= 1 || throw(ArgumentError("n_variables must be at least 1"))
+    return Int(n_variables)
+end
+
+function _ansatz_parameter_names(n_variables::Integer, ansatz)
+    num_qubits = _check_n_variables(n_variables)
+    circuit = ansatz(num_qubits=num_qubits)
+    return qiskit_parameter_names(circuit)
+end
+
+"""
+    VQE.parameter_names(; n_variables, ansatz=VQE.default_ansatz)
+
+Return the Qiskit list-binding order for the selected VQE ansatz.
+"""
+function parameter_names(; n_variables::Integer, ansatz = default_ansatz)
+    return _ansatz_parameter_names(n_variables, ansatz)
+end
+
+function parameter_names(n_variables::Integer; ansatz = default_ansatz)
+    return parameter_names(; n_variables=n_variables, ansatz=ansatz)
+end
+
+function parameter_names(sampler::QUBODrivers.AbstractSampler; ansatz = MOI.get(sampler, VQE.Ansatz()))
+    ising_hamiltonian = quadratic_program(sampler)[0]
+    n_variables = pyconvert(Int, ising_hamiltonian.num_qubits)
+    return parameter_names(; n_variables=n_variables, ansatz=ansatz)
+end
+
+"""
+    VQE.parameter_count(; n_variables, ansatz=VQE.default_ansatz)
+
+Return the expected number of VQE initial parameters for the selected ansatz.
+"""
+function parameter_count(; n_variables::Integer, ansatz = default_ansatz)
+    return length(parameter_names(; n_variables=n_variables, ansatz=ansatz))
+end
+
+function parameter_count(n_variables::Integer; ansatz = default_ansatz)
+    return parameter_count(; n_variables=n_variables, ansatz=ansatz)
+end
+
+function parameter_count(sampler::QUBODrivers.AbstractSampler; ansatz = MOI.get(sampler, VQE.Ansatz()))
+    return length(parameter_names(sampler; ansatz=ansatz))
+end
+
+"""
+    VQE.random_initial_parameters(; n_variables, seed=nothing, rng=nothing, ansatz=VQE.default_ansatz)
+
+Return random VQE angles in Qiskit parameter order. Passing `seed` makes
+the returned vector reproducible.
+"""
+function random_initial_parameters(;
+    n_variables::Integer,
+    seed = nothing,
+    rng = nothing,
+    ansatz = default_ansatz,
+)
+    count = parameter_count(; n_variables=n_variables, ansatz=ansatz)
+    return 2π .* random_unit_values(count; seed=seed, rng=rng)
 end
 
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
@@ -89,6 +157,8 @@ function retrieve(
     channel         = runtime_channel(MOI.get(sampler, VQE.Channel()))
     instance        = runtime_instance(MOI.get(sampler, VQE.Instance()))
     initial_parameters   = MOI.get(sampler, VQE.InitialParameters())
+    initial_parameter_source = MOI.get(sampler, VQE.InitialParameterSource())
+    record_initial_parameters = MOI.get(sampler, VQE.RecordInitialParameters())
     is_local         = MOI.get(sampler, VQE.IsLocal())
     aer_config = AerBackendConfig(
         method=MOI.get(sampler, VQE.AerBackendMethod()),
@@ -101,6 +171,25 @@ function retrieve(
         seed_simulator=MOI.get(sampler, VQE.AerSeedSimulator()),
         seed_transpiler=MOI.get(sampler, VQE.TranspilerSeed()),
     )
+
+    ising_qp = quadratic_program(sampler)
+    ising_hamiltonian = ising_qp[0]
+    num_qubits = pyconvert(Int, ising_hamiltonian.num_qubits)
+    ansatz = ansatz_instance(num_qubits=num_qubits)
+    parameter_names = qiskit_parameter_names(ansatz)
+    expected_parameter_count = length(parameter_names)
+
+    initial_parameter_values = if isnothing(initial_parameters)
+        zeros(expected_parameter_count)
+    else
+        validate_initial_parameters(initial_parameters, expected_parameter_count, "VQE")
+        Float64.(initial_parameters)
+    end
+    initial_parameter_source = if isnothing(initial_parameter_source)
+        isnothing(initial_parameters) ? "default_zero" : "user"
+    else
+        initial_parameter_source
+    end
 
     @pyexec """
     def cost_function(params, ansatz, hamiltonian, estimator):
@@ -122,11 +211,6 @@ function retrieve(
     execution_mode = backend_selection.execution_mode
     backend_label = backend_name(backend)
 
-    ising_qp = quadratic_program(sampler)
-    ising_hamiltonian = ising_qp[0]
-    num_qubits = pyconvert(Int, ising_hamiltonian.num_qubits)
-    ansatz = ansatz_instance(num_qubits=num_qubits)
-
     pass_manager = preset_pass_manager(
         backend;
         optimization_level=3,
@@ -137,11 +221,7 @@ function retrieve(
     ising_hamiltonian = ising_hamiltonian.apply_layout(layout=ansatz_isa.layout)
 
 
-    if isnothing(initial_parameters)
-        initial_parameters = numpy().zeros(pyint(pyconvert(Int, ansatz_isa.num_parameters)))
-    else
-        initial_parameters = numpy().array(initial_parameters)
-    end
+    initial_parameters = numpy().array(initial_parameter_values)
 
     estimator = qiskit_ibm_runtime().EstimatorV2(mode=backend)
     estimator.options.default_shots = num_reads
@@ -172,6 +252,9 @@ function retrieve(
         backend_config=backend_selection.config,
         backend_config_source=backend_selection.source,
         seed_transpiler=aer_config.seed_transpiler,
+        initial_parameters=record_initial_parameters ? initial_parameter_values : nothing,
+        initial_parameter_names=record_initial_parameters ? parameter_names : nothing,
+        initial_parameter_source=record_initial_parameters ? initial_parameter_source : nothing,
     )
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -225,6 +225,21 @@ function run_qubodrivers_suite(optimizer_module)
     end
 end
 
+function expected_maxcut_value(statevector, edges)
+    probabilities = QiskitOpt.PythonCall.pyconvert(
+        Dict{String,Float64},
+        statevector.probabilities_dict(),
+    )
+
+    expected_value = 0.0
+    for (bitstring, probability) in probabilities
+        bits = reverse(Int[digit == '1' for digit in bitstring])
+        expected_value += probability * sum(bits[i] != bits[j] for (i, j) in edges)
+    end
+
+    return expected_value
+end
+
 @testset "Runtime diagnostics and lazy imports" begin
     @test !python_module_loaded("qiskit_ibm_runtime")
 
@@ -346,8 +361,62 @@ end
     @test QAOA.parameter_names(3; number_of_layers=2) == ["β[0]", "β[1]", "γ[0]", "γ[1]"]
     @test QAOA.parameter_count(3; number_of_layers=2) == 4
     @test QAOA.fixed_angle_initial_parameters(number_of_layers=2) == [0.555, 0.293, -0.488, -0.898]
+    @test QAOA.fixed_angle_guarantee(number_of_layers=2) == 0.7559
     @test QAOA.fixed_angle_initial_parameters(number_of_layers=1; gamma_sign=1) == [0.393, 0.616]
     @test_throws ArgumentError QAOA.fixed_angle_initial_parameters(number_of_layers=6)
+    @test_throws ArgumentError QAOA.fixed_angle_guarantee(number_of_layers=6)
+
+    qaoa_cost_operator = QiskitOpt.qiskit().quantum_info.SparsePauliOp.from_list([
+        ("ZI", 1.0),
+        ("IZ", 1.0),
+        ("ZZ", 1.0),
+    ])
+    for number_of_layers in 1:3
+        live_names = QiskitOpt.qiskit_parameter_names(
+            QiskitOpt.qiskit().circuit.library.QAOAAnsatz(
+                qaoa_cost_operator,
+                reps=number_of_layers,
+            ),
+        )
+        @test QAOA.parameter_names(2; number_of_layers=number_of_layers) == live_names
+        @test QAOA.parameter_names(qaoa_cost_operator; number_of_layers=number_of_layers) == live_names
+    end
+
+    k4_edges = [(1, 2), (2, 3), (3, 4), (4, 1), (1, 3), (2, 4)]
+    k4_maxcut_operator = QiskitOpt.qiskit().quantum_info.SparsePauliOp.from_list([
+        ("IIZZ", 0.5),
+        ("IZIZ", 0.5),
+        ("ZIIZ", 0.5),
+        ("IZZI", 0.5),
+        ("ZIZI", 0.5),
+        ("ZZII", 0.5),
+    ])
+    for number_of_layers in 1:3
+        negative_gamma_parameters = QAOA.fixed_angle_initial_parameters(
+            number_of_layers=number_of_layers,
+            gamma_sign=-1,
+        )
+        positive_gamma_parameters = QAOA.fixed_angle_initial_parameters(
+            number_of_layers=number_of_layers,
+            gamma_sign=1,
+        )
+        negative_gamma_state = QiskitOpt.qiskit().quantum_info.Statevector.from_instruction(
+            QiskitOpt.qiskit().circuit.library.QAOAAnsatz(
+                k4_maxcut_operator,
+                reps=number_of_layers,
+            ).assign_parameters(negative_gamma_parameters),
+        )
+        positive_gamma_state = QiskitOpt.qiskit().quantum_info.Statevector.from_instruction(
+            QiskitOpt.qiskit().circuit.library.QAOAAnsatz(
+                k4_maxcut_operator,
+                reps=number_of_layers,
+            ).assign_parameters(positive_gamma_parameters),
+        )
+        negative_gamma_ratio = expected_maxcut_value(negative_gamma_state, k4_edges) / 4
+        positive_gamma_ratio = expected_maxcut_value(positive_gamma_state, k4_edges) / 4
+        @test negative_gamma_ratio >= QAOA.fixed_angle_guarantee(number_of_layers=number_of_layers)
+        @test negative_gamma_ratio > positive_gamma_ratio
+    end
 
     qaoa_seeded = QAOA.random_initial_parameters(number_of_layers=2; seed=1234)
     @test length(qaoa_seeded) == 4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -342,11 +342,66 @@ end
     @test selected.source == "user_backend_factory"
 end
 
+@testset "Initial parameter helpers" begin
+    @test QAOA.parameter_names(3; number_of_layers=2) == ["β[0]", "β[1]", "γ[0]", "γ[1]"]
+    @test QAOA.parameter_count(3; number_of_layers=2) == 4
+    @test QAOA.fixed_angle_initial_parameters(number_of_layers=2) == [0.555, 0.293, -0.488, -0.898]
+    @test QAOA.fixed_angle_initial_parameters(number_of_layers=1; gamma_sign=1) == [0.393, 0.616]
+    @test_throws ArgumentError QAOA.fixed_angle_initial_parameters(number_of_layers=6)
+
+    qaoa_seeded = QAOA.random_initial_parameters(number_of_layers=2; seed=1234)
+    @test length(qaoa_seeded) == 4
+    @test qaoa_seeded == QAOA.random_initial_parameters(number_of_layers=2; seed=1234)
+    @test qaoa_seeded != QAOA.random_initial_parameters(number_of_layers=2; seed=1235)
+
+    vqe_names = VQE.parameter_names(n_variables=3)
+    @test length(vqe_names) == VQE.parameter_count(n_variables=3)
+    @test VQE.parameter_count(n_variables=3) == 24
+    @test first(vqe_names) == "θ[0]"
+    @test last(vqe_names) == "θ[23]"
+
+    vqe_seeded = VQE.random_initial_parameters(n_variables=3; seed=73001)
+    @test length(vqe_seeded) == 24
+    @test vqe_seeded == VQE.random_initial_parameters(n_variables=3; seed=73001)
+    @test vqe_seeded != VQE.random_initial_parameters(n_variables=3; seed=73002)
+end
+
+@testset "Initial parameter validation fails before backend execution" begin
+    previous_builder = QiskitOpt._runtime_service_builder[]
+    QiskitOpt._runtime_service_builder[] = (; kwargs...) -> error("runtime service invoked")
+
+    try
+        qaoa_model, _ = build_model(QAOA.Optimizer)
+        MOI.set(qaoa_model, QAOA.IBMBackend(), "ibm_fez")
+        MOI.set(qaoa_model, QAOA.InitialParameters(), [0.0])
+        @test_throws ArgumentError MOI.optimize!(qaoa_model)
+
+        vqe_model, _ = build_model(VQE.Optimizer)
+        MOI.set(vqe_model, VQE.IBMBackend(), "ibm_fez")
+        MOI.set(vqe_model, VQE.InitialParameters(), [0.0])
+        @test_throws ArgumentError MOI.optimize!(vqe_model)
+    finally
+        QiskitOpt._runtime_service_builder[] = previous_builder
+    end
+end
+
 @testset "Aer backend configuration is recorded in SampleSet metadata" begin
     for (optimizer_factory, optimizer_module, algorithm) in (
         (QAOA.Optimizer, QAOA, "QAOA"),
         (VQE.Optimizer, VQE, "VQE"),
     )
+        initial_parameters = if optimizer_module === QAOA
+            QAOA.fixed_angle_initial_parameters(number_of_layers=1)
+        else
+            VQE.random_initial_parameters(n_variables=3; seed=73001)
+        end
+        initial_parameter_names = if optimizer_module === QAOA
+            QAOA.parameter_names(3; number_of_layers=1)
+        else
+            VQE.parameter_names(n_variables=3)
+        end
+        initial_parameter_source = optimizer_module === QAOA ? QAOA.FIXED_ANGLE_SOURCE : "random_seed_73001"
+
         sampleset = sample_locally_without_runtime_service(
             optimizer_factory,
             optimizer_module,
@@ -355,6 +410,8 @@ end
                 MOI.set(model, module_.AerMaxParallelThreads(), 1)
                 MOI.set(model, module_.AerSeedSimulator(), 1234)
                 MOI.set(model, module_.TranspilerSeed(), 5678)
+                MOI.set(model, module_.InitialParameters(), initial_parameters)
+                MOI.set(model, module_.InitialParameterSource(), initial_parameter_source)
             end;
             max_iterations=1,
             number_of_reads=16,
@@ -368,7 +425,24 @@ end
         @test metadata["backend_configuration"]["max_parallel_threads"] == 1
         @test metadata["seeds"]["simulator"] == 1234
         @test metadata["seeds"]["transpiler"] == 5678
+        @test metadata["initial_parameters"]["source"] == initial_parameter_source
+        @test metadata["initial_parameters"]["parameter_names"] == initial_parameter_names
+        @test metadata["initial_parameters"]["values"] == initial_parameters
     end
+end
+
+@testset "Initial parameter metadata can be disabled" begin
+    sampleset = sample_locally_without_runtime_service(
+        QAOA.Optimizer,
+        QAOA,
+        (model, module_) -> begin
+            MOI.set(model, module_.InitialParameters(), QAOA.fixed_angle_initial_parameters(number_of_layers=1))
+            MOI.set(model, module_.RecordInitialParameters(), false)
+        end;
+        max_iterations=1,
+        number_of_reads=8,
+    )
+    @test !haskey(QUBOTools.metadata(sampleset), "initial_parameters")
 end
 
 @testset "Max-sense objective reporting stays consistent" begin


### PR DESCRIPTION
Closes #18

## Summary
- Add QAOA helper APIs for Qiskit parameter names/counts, deterministic random starts, and Wurtz-Lykov fixed-angle warm starts.
- Add VQE helper APIs for ansatz parameter names/counts and deterministic random starts.
- Validate user-provided `InitialParameters` lengths before backend/runtime execution starts.
- Record initial parameter source, names, and values in `SampleSet` metadata, with `RecordInitialParameters()` to disable recording.
- Document the new helper APIs and metadata behavior.

## Tests
- `Meta.parseall` on `src/QiskitOpt.jl`, `src/QAOA.jl`, `src/VQE.jl`, and `test/runtests.jl`
- `Pkg.test("QiskitOpt")` using Julia 1.10.11 and the existing CondaPkg Python/Qiskit environment
