### PR TITLE
Benchmark julia-actions cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,6 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
Summary

- Adds `julia-actions/cache@v3` to the existing CI matrix.
- Places the cache step after `julia-actions/setup-julia@v3` and before `julia-actions/julia-buildpkg@v1`.
- Leaves package source, tests, and dependencies unchanged.

Benchmark Results

Baseline from issue #24:

| Job | Baseline |
| --- | ---: |
| Julia 1.10 Ubuntu | 2m43s |
| Julia 1 Ubuntu | 4m31s |
| Julia 1 Windows | 7m52s |

First PR run, cache population attempt:

| Job | Total | setup-julia | cache restore | buildpkg | runtest | cache save |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Julia 1.10 Ubuntu | 2m22s | 4s | 1s | 15s | 1m49s | 6s |
| Julia 1 Ubuntu | 4m28s | 9s | 0s | 12s | 3m55s | 8s |
| Julia 1 Windows | 7m28s | 20s | 1s | 33s | 5m48s | 34s |

Second PR run, warm-cache attempt:

| Job | Total | setup-julia | cache restore | buildpkg | runtest | cache save |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Julia 1.10 Ubuntu | 1m51s | 5s | 9s | 11s | 1m11s | 7s |
| Julia 1 Ubuntu | 2m06s | 8s | 10s | 8s | 1m24s | 9s |
| Julia 1 Windows | 3m16s | 15s | 32s | 9s | 1m54s | 14s |

Critical path improved from 7m52s to 3m16s, a 276s reduction, about 59%.

Cache Evidence

- The warm-cache run logged `Cache hit for restore-key` from run attempt 1 for each matrix job.
- The warm-cache run logged `Cache restored successfully` and `Cache saved successfully` for each matrix job.

Checks

- `git diff --check` passed locally.
- First PR CI attempt passed all matrix jobs with `gh pr checks 25 --watch --fail-fast`.
- Second PR CI attempt passed all matrix jobs with `gh run watch 27129737723 --exit-status`.

Closes #24
