### PR TITLE
[codex] Integrate QUBO v0.6 release stack

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,4 @@ QUBO = "ce8c2e91-a970-4681-856b-16178c24a30c"
 [compat]
 PythonCall = "0.9"
 julia = "1.10"
-QUBO = "0.4, 0.5"
+QUBO = "0.6"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The local backend check verifies the default Aer backend. Current QAOA/VQE local
 set_attribute(model, VQE.NumberOfReads(), 1000) # or QAOA.NumberOfReads
 
 # Optional final sampling shots, separate from optimizer/estimator shots.
+# If unset, final sampling uses NumberOfReads().
 set_attribute(model, QiskitOpt.QUBODrivers.FinalNumberOfReads(), 8192)
 
 # Maximum optimizer iterations

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ The local backend check verifies the default Aer backend. Current QAOA/VQE local
 # Number of shots
 set_attribute(model, VQE.NumberOfReads(), 1000) # or QAOA.NumberOfReads
 
+# Optional final sampling shots, separate from optimizer/estimator shots.
+set_attribute(model, QiskitOpt.QUBODrivers.FinalNumberOfReads(), 8192)
+
 # Maximum optimizer iterations
 set_attribute(model, VQE.MaximumIterations(), 100) # or QAOA.MaximumIterations
 

--- a/examples/ds_mfg_qubo/DSMFGQUBOExample.jl
+++ b/examples/ds_mfg_qubo/DSMFGQUBOExample.jl
@@ -353,6 +353,7 @@ end
 
 function _configure_qaoa!(model, instance::QUBOInstance; number_of_reads::Integer, maximum_iterations::Integer)
     MOI.set(model, QAOA.NumberOfReads(), number_of_reads)
+    MOI.set(model, QUBODrivers.FinalNumberOfReads(), number_of_reads)
     MOI.set(model, QAOA.MaximumIterations(), maximum_iterations)
     MOI.set(model, QAOA.NumberOfLayers(), 1)
     MOI.set(model, QAOA.InitialParameters(), QAOA.fixed_angle_initial_parameters(number_of_layers = 1))
@@ -366,6 +367,7 @@ end
 
 function _configure_vqe!(model, instance::QUBOInstance; number_of_reads::Integer, maximum_iterations::Integer)
     MOI.set(model, VQE.NumberOfReads(), number_of_reads)
+    MOI.set(model, QUBODrivers.FinalNumberOfReads(), number_of_reads)
     MOI.set(model, VQE.MaximumIterations(), maximum_iterations)
     MOI.set(model, VQE.InitialParameters(), VQE.random_initial_parameters(n_variables = instance.n_variables, seed = 73001))
     MOI.set(model, VQE.InitialParameterSource(), "random_seed_73001")

--- a/examples/ds_mfg_qubo/README.md
+++ b/examples/ds_mfg_qubo/README.md
@@ -52,6 +52,7 @@ parameters, and deterministic simulator/transpiler seeds where supported:
 
 - `QAOA.NumberOfLayers() = 1`
 - `NumberOfReads() = 128`
+- `QUBODrivers.FinalNumberOfReads() = 128`
 - `MaximumIterations() = 10`
 - `AerPrecision() = "single"`
 - `AerMaxParallelThreads() = 1`
@@ -64,6 +65,7 @@ The package test suite includes this module and validates the loader,
 classical objective bookkeeping, cached distributions, and SVG rendering path.
 It does not run the Aer simulation in CI.
 
-Reusable export or objective-bookkeeping APIs should live in lower-level
-packages such as `QUBOTools.jl`, `QUBODrivers.jl`, or `ToQUBO.jl` once those
-interfaces exist. This example keeps only tutorial-specific glue locally.
+Reusable export, objective-bookkeeping, final-read, and reformulation-metadata
+APIs live in lower-level packages such as `QUBOTools.jl`, `QUBODrivers.jl`, and
+`ToQUBO.jl`. This example keeps only tutorial-specific CSV parsing, comparison,
+and SVG rendering glue locally.

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -218,6 +218,7 @@ function retrieve(
     # Retrieve Attributes
     max_iter        = MOI.get(sampler, QAOA.MaximumIterations())
     num_reads       = MOI.get(sampler, QAOA.NumberOfReads())
+    final_num_reads = MOI.get(sampler, QUBODrivers.FinalNumberOfReads())
     num_layers      = MOI.get(sampler, QAOA.NumberOfLayers())
     ibm_backend     = MOI.get(sampler, QAOA.IBMBackend())
     ibm_fake_backend = MOI.get(sampler, QAOA.IBMFakeBackend())
@@ -309,7 +310,7 @@ function retrieve(
     optimized_qc = pass_manager.run(qc)
 
     qiskit_sampler = qiskit_ibm_runtime().SamplerV2(mode=backend)
-    sampling_result = qiskit_sampler.run(pylist([optimized_qc]), shots=pyint(num_reads)).result()[0]
+    sampling_result = qiskit_sampler.run(pylist([optimized_qc]), shots=pyint(final_num_reads)).result()[0]
     samples = sampling_result.data.meas.get_counts()
 
     callback(result, samples)

--- a/src/VQE.jl
+++ b/src/VQE.jl
@@ -151,6 +151,7 @@ function retrieve(
     # Retrieve Attributes
     max_iter        = MOI.get(sampler, VQE.MaximumIterations())
     num_reads       = MOI.get(sampler, VQE.NumberOfReads())
+    final_num_reads = MOI.get(sampler, QUBODrivers.FinalNumberOfReads())
     ibm_backend     = MOI.get(sampler, VQE.IBMBackend())
     ibm_fake_backend = MOI.get(sampler, VQE.IBMFakeBackend())
     ansatz_instance = MOI.get(sampler, VQE.Ansatz())
@@ -240,7 +241,7 @@ function retrieve(
     optimized_qc = pass_manager.run(qc)
 
     qiskit_sampler = qiskit_ibm_runtime().SamplerV2(mode=backend)
-    sampling_result = qiskit_sampler.run(pylist([optimized_qc]), shots=pyint(num_reads)).result()[0]
+    sampling_result = qiskit_sampler.run(pylist([optimized_qc]), shots=pyint(final_num_reads)).result()[0]
     samples = sampling_result.data.meas.get_counts()
 
     callback(result, samples)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -547,6 +547,15 @@ end
 
 @testset "Final sampling reads use generic QUBODrivers attribute" begin
     for (optimizer_factory, optimizer_module) in ((QAOA.Optimizer, QAOA), (VQE.Optimizer, VQE))
+        fallback_number_of_reads = 32
+        fallback_sampleset = sample_locally_without_runtime_service(
+            optimizer_factory,
+            optimizer_module;
+            max_iterations=1,
+            number_of_reads=fallback_number_of_reads,
+        )
+        @test sum(QUBOTools.reads(sample) for sample in fallback_sampleset) == fallback_number_of_reads
+
         final_number_of_reads = 48
         sampleset = sample_locally_without_runtime_service(
             optimizer_factory,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -545,6 +545,21 @@ end
     end
 end
 
+@testset "Final sampling reads use generic QUBODrivers attribute" begin
+    for (optimizer_factory, optimizer_module) in ((QAOA.Optimizer, QAOA), (VQE.Optimizer, VQE))
+        final_number_of_reads = 48
+        sampleset = sample_locally_without_runtime_service(
+            optimizer_factory,
+            optimizer_module,
+            (model, _) -> MOI.set(model, QUBODrivers.FinalNumberOfReads(), final_number_of_reads);
+            max_iterations=1,
+            number_of_reads=8,
+        )
+
+        @test sum(QUBOTools.reads(sample) for sample in sampleset) == final_number_of_reads
+    end
+end
+
 @testset "Initial parameter metadata can be disabled" begin
     sampleset = sample_locally_without_runtime_service(
         QAOA.Optimizer,


### PR DESCRIPTION
## Summary

- Update QiskitOpt compat to consume the released `QUBO v0.6` ecosystem stack.
- Wire QAOA and VQE final sampling to the generic `QUBODrivers.FinalNumberOfReads()` attribute.
- Document the separate final sampling read count and update the DS-MFG example configuration notes.
- Add a QAOA/VQE integration test that verifies final emitted sample reads use the generic driver attribute.

## Dependency stack validated

- `QUBO v0.6.0`
- `QUBODrivers v0.6.0`
- `QUBOTools v0.13.0`
- `ToQUBO v0.4.0`

## Validation

- `git diff --check`
- `julia +release --project=. -e 'using Test; include("test/runtests.jl")'`
- `julia +release --project=. -e 'import Pkg; Pkg.test()'`
- `julia +release --project=. examples/ds_mfg_qubo/ds_mfg_qubo_qiskitopt.jl`

## Notes

This is the QiskitOpt integration step after the lower-level Phase 1-4 releases. It leaves the package version at `0.4.0`, which is already declared in `Project.toml`; this PR prepares that release to depend on the finalized ecosystem versions.
