### PR TITLE
[codex] Fix TagBot token configuration

### DIFF
--- a/.github/workflows/tagbot.yml
+++ b/.github/workflows/tagbot.yml
@@ -12,4 +12,3 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
## Summary

Remove the `ssh: ${{ secrets.DOCUMENTER_KEY }}` input from the TagBot workflow so TagBot uses its default `GITHUB_TOKEN` path instead of a missing or invalid SSH deploy key.

## Why

The `v0.4.0` release was registered and published, but the automatic TagBot run failed while pushing over SSH because the configured deploy key was not accepted. Since this repository does not currently have a working write deploy key configured for TagBot, the workflow should not force SSH mode.

## Validation

- `git diff --check`
- Confirmed the failed TagBot run was caused by SSH authentication failure.

## Follow-up

If maintainers want TagBot-created tags to trigger downstream workflows, or want automatic tagging for releases whose tagged commit modifies `.github/workflows`, configure a dedicated write deploy key and restore the `ssh` input intentionally.