### PR TITLE
Fix Aer MPS option-name mapping

### DIFF
--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -429,8 +429,16 @@ function aer_backend_options(config::AerBackendConfig)
     _push_option!(options, :precision, config.precision)
     _push_option!(options, :max_parallel_threads, config.max_parallel_threads)
     _push_option!(options, :mps_omp_threads, config.mps_omp_threads)
-    _push_option!(options, :mps_truncation_threshold, config.mps_truncation_threshold)
-    _push_option!(options, :mps_max_bond_dimension, config.mps_max_bond_dimension)
+    _push_option!(
+        options,
+        :matrix_product_state_truncation_threshold,
+        config.mps_truncation_threshold,
+    )
+    _push_option!(
+        options,
+        :matrix_product_state_max_bond_dimension,
+        config.mps_max_bond_dimension,
+    )
     _push_option!(options, :mps_sample_measure_algorithm, config.mps_sample_measure_algorithm)
     _push_option!(options, :seed_simulator, config.seed_simulator)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -357,11 +357,26 @@ end
     @test options.precision == "single"
     @test options.max_parallel_threads == 2
     @test options.mps_omp_threads == 1
-    @test options.mps_truncation_threshold == 1.0e-6
-    @test options.mps_max_bond_dimension == 32
+    @test options.matrix_product_state_truncation_threshold == 1.0e-6
+    @test options.matrix_product_state_max_bond_dimension == 32
+    @test !(:mps_truncation_threshold in keys(options))
+    @test !(:mps_max_bond_dimension in keys(options))
     @test options.mps_sample_measure_algorithm == "mps_apply_measure"
     @test options.seed_simulator == 1234
     @test !(:seed_transpiler in keys(options))
+
+    smoke_config = QiskitOpt.AerBackendConfig(
+        method="matrix_product_state",
+        precision="single",
+        max_parallel_threads=2,
+        mps_omp_threads=1,
+        mps_truncation_threshold=1.0e-6,
+        mps_max_bond_dimension=32,
+        mps_sample_measure_algorithm="mps_apply_measure",
+        seed_simulator=1234,
+        seed_transpiler=5678,
+    )
+    @test !isnothing(QiskitOpt.local_aer_backend(smoke_config))
 
     metadata = QiskitOpt.empty_metadata(
         "QAOA",


### PR DESCRIPTION
## Summary

- Map `AerBackendConfig.mps_truncation_threshold` to Aer's accepted `matrix_product_state_truncation_threshold` keyword.
- Map `AerBackendConfig.mps_max_bond_dimension` to Aer's accepted `matrix_product_state_max_bond_dimension` keyword.
- Update Aer helper tests and add a local Aer construction smoke test with all Aer config attributes enabled.

## Tests

- `julia --project=. -e 'using Pkg; Pkg.test()'`

Closes #29
