### PR TITLE
Release v0.4.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QiskitOpt"
 uuid = "81b20daf-e62b-4502-a0d1-aa084de80e33"
 authors = ["pedromxavier <pedroxavier@psr-inc.com>", "pedroripper <pedroripper@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"


### PR DESCRIPTION
## Summary

- Bump QiskitOpt from `0.4.0` to `0.4.1` for the Aer MPS option-name mapping patch.

## Tests

- `julia --project=. -e 'using Pkg; Pkg.test()'`

## Release notes

- Fixes local Aer matrix-product-state backend construction when `mps_truncation_threshold` or `mps_max_bond_dimension` is configured.
