### PR TITLE
Docs: add QAOA best practices guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ julia --project=. examples/ds_mfg_qubo/ds_mfg_qubo_qiskitopt.jl
 Set `QISKITOPT_DSMFG_RERUN=true` to regenerate the sample distributions through
 local Aer.
 
+## Guides
+
+- [QAOA best practices](docs/qaoa_best_practices.md) explains how to start
+  locally with Aer, choose reproducible QAOA initial parameters, record metadata,
+  and move selected runs to IBM hardware.
+
 ## Runtime Diagnostics
 Use `check_runtime` to verify the Julia/Python bridge and local Qiskit stack before running an optimizer:
 

--- a/docs/qaoa_best_practices.md
+++ b/docs/qaoa_best_practices.md
@@ -1,0 +1,172 @@
+# QAOA Best Practices
+
+This guide maps the QAOA workflow guidance from
+[qopt-best-practices](https://github.com/qiskit-community/qopt-best-practices),
+[qaoa_training_pipeline](https://github.com/qiskit-community/qaoa_training_pipeline),
+and [arXiv:2606.05311](https://arxiv.org/abs/2606.05311) onto the
+QiskitOpt.jl attributes that users should set explicitly.
+
+The short version is: start locally, make the run reproducible, record where
+the initial angles came from, and move to IBM hardware only after the local
+configuration is stable.
+
+## Recommended Workflow
+
+1. Build and debug the JuMP/MOI model with the default local Aer backend.
+2. Fix the QAOA depth, shot counts, simulator seed, transpiler seed, and initial
+   parameters before comparing runs.
+3. Validate several initial-parameter strategies locally before spending IBM
+   hardware time.
+4. If hardware topology matters, do the hardware-aware transpilation and mapping
+   work in an upstream workflow, then pass only the selected backend, seeds, and
+   angles into QiskitOpt.jl.
+5. Treat hardware execution as final validation and sampling, not as the first
+   place to tune angles.
+
+## QiskitOpt.jl Attributes To Set
+
+| Purpose | QAOA attribute or helper |
+| --- | --- |
+| QAOA depth | `QiskitOpt.QAOA.NumberOfLayers()` |
+| Optimizer shots | `QiskitOpt.QAOA.NumberOfReads()` |
+| Final sampling shots | `QiskitOpt.QUBODrivers.FinalNumberOfReads()` |
+| Optimizer iterations | `QiskitOpt.QAOA.MaximumIterations()` |
+| Initial angle values | `QiskitOpt.QAOA.InitialParameters()` |
+| Initial angle provenance | `QiskitOpt.QAOA.InitialParameterSource()` |
+| Initial metadata recording | `QiskitOpt.QAOA.RecordInitialParameters()` |
+| Local Aer method | `QiskitOpt.QAOA.AerBackendMethod()` |
+| Local Aer precision | `QiskitOpt.QAOA.AerPrecision()` |
+| Local Aer simulator seed | `QiskitOpt.QAOA.AerSeedSimulator()` |
+| Qiskit transpiler seed | `QiskitOpt.QAOA.TranspilerSeed()` |
+| Aer MPS controls | `AerMPSOmpThreads()`, `AerMPSTruncationThreshold()`, `AerMPSMaxBondDimension()`, `AerMPSSampleMeasureAlgorithm()` |
+| Named IBM backend | `QiskitOpt.QAOA.IBMBackend()` |
+| Local emulation of an IBM backend | `QiskitOpt.QAOA.IBMBackend()` plus `QiskitOpt.QAOA.IsLocal()` |
+| IBM Runtime account selection | `QiskitOpt.QAOA.Channel()` and `QiskitOpt.QAOA.Instance()` |
+| Custom local backend factory | `QiskitOpt.QAOA.IBMFakeBackend()` |
+
+QiskitOpt.jl defaults to local Aer execution when `IBMBackend()` is unset. The
+default Aer method is `matrix_product_state`, so a first QAOA run does not need
+an IBM token.
+
+```julia
+using JuMP
+using QiskitOpt
+
+model = Model(QiskitOpt.QAOA.Optimizer)
+
+set_attribute(model, QiskitOpt.QAOA.NumberOfLayers(), 2)
+set_attribute(model, QiskitOpt.QAOA.NumberOfReads(), 1024)
+set_attribute(model, QiskitOpt.QUBODrivers.FinalNumberOfReads(), 8192)
+set_attribute(model, QiskitOpt.QAOA.MaximumIterations(), 100)
+
+set_attribute(model, QiskitOpt.QAOA.AerBackendMethod(), "matrix_product_state")
+set_attribute(model, QiskitOpt.QAOA.AerSeedSimulator(), 73001)
+set_attribute(model, QiskitOpt.QAOA.TranspilerSeed(), 73001)
+```
+
+## Initial Parameters
+
+QiskitOpt.jl follows Qiskit's QAOA parameter order: all beta angles followed by
+all gamma angles. Use `QiskitOpt.QAOA.parameter_names(...)` before setting
+initial values when you want to audit the order.
+
+The available choices are:
+
+- Default zero vector. Leave `InitialParameters()` unset. Metadata records the
+  source as `default_zero`.
+- Seeded random starts. Generate values with
+  `QiskitOpt.QAOA.random_initial_parameters(number_of_layers=p, seed=seed)` and
+  store a matching `InitialParameterSource()`.
+- Fixed Wurtz-Lykov angles. Use
+  `QiskitOpt.QAOA.fixed_angle_initial_parameters(...)` for the built-in
+  3-regular tree table, and record `QiskitOpt.QAOA.FIXED_ANGLE_SOURCE`.
+- Schedule-based starts. The schedule helpers tracked in issue
+  [#34](https://github.com/JuliaQUBO/QiskitOpt.jl/issues/34) should produce a
+  Qiskit-ordered vector that is passed through `InitialParameters()` with a
+  descriptive `InitialParameterSource()`.
+
+```julia
+p = 2
+seed = 73001
+
+random_start = QiskitOpt.QAOA.random_initial_parameters(
+    number_of_layers=p,
+    seed=seed,
+)
+set_attribute(model, QiskitOpt.QAOA.NumberOfLayers(), p)
+set_attribute(model, QiskitOpt.QAOA.InitialParameters(), random_start)
+set_attribute(model, QiskitOpt.QAOA.InitialParameterSource(), "random_seed_73001")
+```
+
+```julia
+fixed_start = QiskitOpt.QAOA.fixed_angle_initial_parameters(
+    number_of_layers=2,
+    gamma_sign=-1,
+)
+set_attribute(model, QiskitOpt.QAOA.InitialParameters(), fixed_start)
+set_attribute(
+    model,
+    QiskitOpt.QAOA.InitialParameterSource(),
+    QiskitOpt.QAOA.FIXED_ANGLE_SOURCE,
+)
+```
+
+The returned `SampleSet` metadata records `metadata["initial_parameters"]` with
+the source, parameter names, and values when `RecordInitialParameters()` is
+true. Keep that enabled for experiments where angles are compared across
+simulators, seeds, or hardware backends.
+
+## Moving From Aer To IBM Hardware
+
+Use three stages when hardware execution is the goal:
+
+1. Local Aer without `IBMBackend()` for fast model and parameter checks.
+2. Local Aer emulation of a named IBM backend by setting `IBMBackend()` and
+   `IsLocal()` to `true`.
+3. Real IBM hardware by setting the same `IBMBackend()` and `IsLocal()` to
+   `false`.
+
+```julia
+# Stage 2: emulate a named IBM backend locally through Aer.
+set_attribute(model, QiskitOpt.QAOA.IBMBackend(), "ibm_fez")
+set_attribute(model, QiskitOpt.QAOA.IsLocal(), true)
+
+# Stage 3: submit to the selected IBM backend.
+set_attribute(model, QiskitOpt.QAOA.IsLocal(), false)
+```
+
+For hardware runs, configure IBM Runtime credentials through the documented
+environment variables or attributes:
+
+- `QISKIT_IBM_TOKEN`
+- `QISKIT_IBM_INSTANCE`, or `QiskitOpt.QAOA.Instance()`
+- `QISKIT_IBM_CHANNEL`, or `QiskitOpt.QAOA.Channel()`
+
+Keep `AerSeedSimulator()` and `TranspilerSeed()` set while transitioning through
+these stages so metadata can explain differences between local and hardware
+runs.
+
+## Upstream Boundary
+
+QiskitOpt.jl should remain the JuMP/MOI adapter that sends a QUBO to Qiskit,
+selects the execution backend, records seeds and angle metadata, and returns
+samples. Broader QAOA research workflows belong upstream:
+
+| Belongs in QiskitOpt.jl | Belongs upstream |
+| --- | --- |
+| `IBMBackend()`, `IsLocal()`, `IBMFakeBackend()`, Aer attributes, and seeds | Hardware-aware transpilation recipes from `qopt-best-practices` |
+| `InitialParameters()` and `InitialParameterSource()` | MPS, Pauli propagation, parameter-transfer, and schedule-training pipelines |
+| Result metadata for backend configuration, seeds, and starting angles | SAT mapping, SWAP strategies, qubit selection, and CVaR training loops |
+
+The adapter boundary is intentional. If a workflow trains angles with
+`qaoa_training_pipeline`, Pauli propagation, MPS, fixed-angle transfer, or a
+hardware-aware mapping strategy, QiskitOpt.jl should receive the final QAOA
+depth, ordered angle vector, backend choice, and reproducibility metadata. It
+should not reimplement those generic QAOA capabilities inside the optimizer.
+
+The paper behind arXiv:2606.05311 makes the same operational point: approximate
+energy evaluators such as MPS and Pauli propagation can train utility-scale
+angles, but the selected angles still need careful local and hardware
+validation. Dense instances, topology-sensitive MPS runs, and hardware-near
+circuits require workflow-level benchmarking rather than package-specific
+shortcuts.

--- a/docs/qaoa_best_practices.md
+++ b/docs/qaoa_best_practices.md
@@ -38,7 +38,7 @@ configuration is stable.
 | Local Aer precision | `QiskitOpt.QAOA.AerPrecision()` |
 | Local Aer simulator seed | `QiskitOpt.QAOA.AerSeedSimulator()` |
 | Qiskit transpiler seed | `QiskitOpt.QAOA.TranspilerSeed()` |
-| Aer MPS controls | `AerMPSOmpThreads()`, `AerMPSTruncationThreshold()`, `AerMPSMaxBondDimension()`, `AerMPSSampleMeasureAlgorithm()` |
+| Aer MPS controls | `QiskitOpt.QAOA.AerMPSOmpThreads()`, `QiskitOpt.QAOA.AerMPSTruncationThreshold()`, `QiskitOpt.QAOA.AerMPSMaxBondDimension()`, `QiskitOpt.QAOA.AerMPSSampleMeasureAlgorithm()` |
 | Named IBM backend | `QiskitOpt.QAOA.IBMBackend()` |
 | Local emulation of an IBM backend | `QiskitOpt.QAOA.IBMBackend()` plus `QiskitOpt.QAOA.IsLocal()` |
 | IBM Runtime account selection | `QiskitOpt.QAOA.Channel()` and `QiskitOpt.QAOA.Instance()` |


### PR DESCRIPTION
Summary
- Add `docs/qaoa_best_practices.md` with a practical QAOA workflow for QiskitOpt.jl users.
- Link the guide from the main README.
- Document the upstream boundary for hardware-aware transpilation, training pipelines, MPS/Pauli propagation, SAT mapping, SWAP strategies, qubit selection, and CVaR loops.

Tests
- `git diff --check`
- `julia --project=. -e 'using Pkg; Pkg.test()'`

Closes #33
