### PR TITLE
Add QAOA schedule initializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ qaoa_guarantee = QiskitOpt.QAOA.fixed_angle_guarantee(number_of_layers=2)
 set_attribute(model, QiskitOpt.QAOA.NumberOfLayers(), 2)
 set_attribute(model, QiskitOpt.QAOA.InitialParameters(), qaoa_start)
 set_attribute(model, QiskitOpt.QAOA.InitialParameterSource(), QiskitOpt.QAOA.FIXED_ANGLE_SOURCE)
+
+schedule_start = QiskitOpt.QAOA.linear_ramp_initial_parameters(number_of_layers=2)
+set_attribute(model, QiskitOpt.QAOA.InitialParameters(), schedule_start)
+set_attribute(model, QiskitOpt.QAOA.InitialParameterSource(), "linear_ramp_arxiv_2606_05311")
 ```
 
 ```julia

--- a/docs/qaoa_best_practices.md
+++ b/docs/qaoa_best_practices.md
@@ -80,9 +80,10 @@ The available choices are:
 - Fixed Wurtz-Lykov angles. Use
   `QiskitOpt.QAOA.fixed_angle_initial_parameters(...)` for the built-in
   3-regular tree table, and record `QiskitOpt.QAOA.FIXED_ANGLE_SOURCE`.
-- Schedule-based starts. The schedule helpers tracked in issue
-  [#34](https://github.com/JuliaQUBO/QiskitOpt.jl/issues/34) should produce a
-  Qiskit-ordered vector that is passed through `InitialParameters()` with a
+- Schedule-based starts. Use
+  `QiskitOpt.QAOA.linear_ramp_initial_parameters(...)`,
+  `QiskitOpt.QAOA.tqa_initial_parameters(...)`, or
+  `QiskitOpt.QAOA.interpolated_initial_parameters(...)`, then record a
   descriptive `InitialParameterSource()`.
 
 ```julia
@@ -109,6 +110,18 @@ set_attribute(
     QiskitOpt.QAOA.InitialParameterSource(),
     QiskitOpt.QAOA.FIXED_ANGLE_SOURCE,
 )
+```
+
+```julia
+schedule_start = QiskitOpt.QAOA.linear_ramp_initial_parameters(
+    number_of_layers=p,
+    delta_beta=0.35,
+    delta_gamma=0.75,
+    gamma_sign=-1,
+)
+set_attribute(model, QiskitOpt.QAOA.NumberOfLayers(), p)
+set_attribute(model, QiskitOpt.QAOA.InitialParameters(), schedule_start)
+set_attribute(model, QiskitOpt.QAOA.InitialParameterSource(), "linear_ramp_arxiv_2606_05311")
 ```
 
 The returned `SampleSet` metadata records `metadata["initial_parameters"]` with

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -158,6 +158,73 @@ function random_initial_parameters(; number_of_layers::Integer, seed = nothing, 
 end
 
 """
+    QAOA.linear_ramp_initial_parameters(; number_of_layers, delta_beta=0.35, delta_gamma=0.75, gamma_sign=-1)
+
+Return Linear Ramp QAOA angles in Qiskit's list-binding order.
+"""
+function linear_ramp_initial_parameters(;
+    number_of_layers::Integer,
+    delta_beta::Real = 0.35,
+    delta_gamma::Real = 0.75,
+    gamma_sign::Real = -1,
+)
+    p = _check_number_of_layers(number_of_layers)
+    beta = [delta_beta * (1 - i / p) for i in 0:(p - 1)]
+    gamma = [gamma_sign * delta_gamma * ((i + 1) / p) for i in 0:(p - 1)]
+    return Float64[v for v in vcat(beta, gamma)]
+end
+
+"""
+    QAOA.tqa_initial_parameters(; number_of_layers, delta_t=0.75, gamma_sign=-1)
+
+Return Trotterized Quantum Annealing QAOA angles in Qiskit's list-binding order.
+"""
+function tqa_initial_parameters(;
+    number_of_layers::Integer,
+    delta_t::Real = 0.75,
+    gamma_sign::Real = -1,
+)
+    p = _check_number_of_layers(number_of_layers)
+    beta = [delta_t * (1 - i / p) for i in 1:p]
+    gamma = [gamma_sign * delta_t * (i / p) for i in 1:p]
+    return Float64[v for v in vcat(beta, gamma)]
+end
+
+function _interpolate_to_next_depth(values::AbstractVector{<:Real})
+    p = length(values)
+    interpolated = Vector{Float64}(undef, p + 1)
+    for i in 1:(p + 1)
+        left = i == 1 ? 0.0 : Float64(values[i - 1])
+        right = i == p + 1 ? 0.0 : Float64(values[i])
+        interpolated[i] = ((i - 1) / p) * left + ((p - i + 1) / p) * right
+    end
+    return interpolated
+end
+
+"""
+    QAOA.interpolated_initial_parameters(previous_parameters; gamma_sign=1)
+
+Convert a depth-`p` Qiskit-ordered QAOA parameter vector into a depth-`p + 1`
+vector by linearly interpolating the beta and gamma blocks separately.
+"""
+function interpolated_initial_parameters(
+    previous_parameters::AbstractVector;
+    gamma_sign::Real = 1,
+)
+    count = length(previous_parameters)
+    count >= 2 || throw(ArgumentError("previous_parameters must contain beta and gamma blocks for at least one layer"))
+    iseven(count) || throw(ArgumentError("previous_parameters length must be even"))
+    all(parameter -> parameter isa Real, previous_parameters) ||
+        throw(ArgumentError("previous_parameters must contain real values"))
+
+    p = div(count, 2)
+    numeric_parameters = Float64.(previous_parameters)
+    beta = _interpolate_to_next_depth(numeric_parameters[1:p])
+    gamma = _interpolate_to_next_depth(numeric_parameters[(p + 1):end])
+    return Float64[v for v in vcat(beta, gamma_sign .* gamma)]
+end
+
+"""
     QAOA.fixed_angle_guarantee(; number_of_layers, family=:wurtz_lykov_3regular_tree)
 
 Return the approximation-ratio guarantee reported with the built-in fixed-angle

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -426,6 +426,45 @@ end
     @test_throws ArgumentError QAOA.fixed_angle_initial_parameters(number_of_layers=6)
     @test_throws ArgumentError QAOA.fixed_angle_guarantee(number_of_layers=6)
 
+    @test QAOA.linear_ramp_initial_parameters(number_of_layers=4) ≈ [
+        0.35,
+        0.2625,
+        0.175,
+        0.0875,
+        -0.1875,
+        -0.375,
+        -0.5625,
+        -0.75,
+    ]
+    @test QAOA.linear_ramp_initial_parameters(
+        number_of_layers=3;
+        delta_beta=0.6,
+        delta_gamma=1.2,
+        gamma_sign=1,
+    ) ≈ [0.6, 0.4, 0.2, 0.4, 0.8, 1.2]
+
+    @test QAOA.tqa_initial_parameters(number_of_layers=3) ≈ [0.5, 0.25, 0.0, -0.25, -0.5, -0.75]
+    @test QAOA.tqa_initial_parameters(number_of_layers=4; delta_t=0.8, gamma_sign=1) ≈ [
+        0.6,
+        0.4,
+        0.2,
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+    ]
+
+    prior_qaoa_parameters = [0.2, 0.4, -0.6, -1.0]
+    @test QAOA.interpolated_initial_parameters(prior_qaoa_parameters) ≈ [0.2, 0.3, 0.4, -0.6, -0.8, -1.0]
+    @test QAOA.interpolated_initial_parameters(prior_qaoa_parameters; gamma_sign=-1) ≈ [0.2, 0.3, 0.4, 0.6, 0.8, 1.0]
+
+    @test_throws ArgumentError QAOA.linear_ramp_initial_parameters(number_of_layers=0)
+    @test_throws ArgumentError QAOA.tqa_initial_parameters(number_of_layers=0)
+    @test_throws ArgumentError QAOA.interpolated_initial_parameters(Float64[])
+    @test_throws ArgumentError QAOA.interpolated_initial_parameters([1.0, 2.0, 3.0])
+    @test_throws ArgumentError QAOA.interpolated_initial_parameters(Any[1.0, "not-real"])
+
     qaoa_cost_operator = QiskitOpt.qiskit().quantum_info.SparsePauliOp.from_list([
         ("ZI", 1.0),
         ("IZ", 1.0),


### PR DESCRIPTION
Summary:
- Add QAOA linear ramp, TQA, and depth-increment interpolation initial-parameter helpers.
- Keep all helpers in Qiskit beta-then-gamma binding order and return `Vector{Float64}`.
- Document schedule-vector use through `InitialParameters()` and `InitialParameterSource()`.

Tests:
- `julia --project=. -e 'using Pkg; Pkg.test()'` passed.

Closes #34
