### PR TITLE
Add QAOA pass-manager factory hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,33 @@ set_attribute(
 You can still provide any zero-argument function that returns a Qiskit backend through `IBMFakeBackend()`.
 When `IBMFakeBackend()` is set to an explicit factory, that factory is used as-is and the Aer backend-construction attributes above do not modify it. Use `local_aer_backend_factory(...)` when you want QiskitOpt to retain the factory's Aer configuration in result metadata.
 
+## Custom QAOA Pass Managers
+`QAOA.Optimizer` also accepts an optional pass-manager factory for users who
+want to plug in hardware-aware QAOA transpilation flows from tooling such as
+`qiskit-community/qopt-best-practices` without adding those tools as
+QiskitOpt.jl dependencies. The hook is QAOA-only; VQE continues to use the
+built-in level-3 preset pass manager.
+
+```julia
+function qaoa_pass_manager(backend; optimization_level=3, seed_transpiler=nothing)
+    # Replace this body with a hardware-aware pass-manager recipe from your
+    # Python/Qiskit workflow.
+    return QiskitOpt.preset_pass_manager(
+        backend;
+        optimization_level=optimization_level,
+        seed_transpiler=seed_transpiler,
+    )
+end
+
+set_attribute(model, QiskitOpt.QAOA.PassManagerFactory(), qaoa_pass_manager)
+```
+
+The factory receives the selected backend. QiskitOpt.jl passes
+`optimization_level=3` and `TranspilerSeed()` as `seed_transpiler` when the
+callable accepts those keywords. The returned pass manager is used for both the
+optimization ansatz and the final measured circuit, and result metadata records
+whether QAOA used the default preset path or a custom factory.
+
 ## Choosing a Local Backend
 
 ```julia

--- a/docs/qaoa_best_practices.md
+++ b/docs/qaoa_best_practices.md
@@ -43,6 +43,7 @@ configuration is stable.
 | Local emulation of an IBM backend | `QiskitOpt.QAOA.IBMBackend()` plus `QiskitOpt.QAOA.IsLocal()` |
 | IBM Runtime account selection | `QiskitOpt.QAOA.Channel()` and `QiskitOpt.QAOA.Instance()` |
 | Custom local backend factory | `QiskitOpt.QAOA.IBMFakeBackend()` |
+| Custom QAOA pass-manager factory | `QiskitOpt.QAOA.PassManagerFactory()` |
 
 QiskitOpt.jl defaults to local Aer execution when `IBMBackend()` is unset. The
 default Aer method is `matrix_product_state`, so a first QAOA run does not need
@@ -159,6 +160,42 @@ Keep `AerSeedSimulator()` and `TranspilerSeed()` set while transitioning through
 these stages so metadata can explain differences between local and hardware
 runs.
 
+## Hardware-Aware Pass Managers
+
+For advanced QAOA workflows, `QAOA.PassManagerFactory()` lets you override only
+the QAOA transpilation path while keeping backend selection, parameter
+optimization, sampling, and metadata inside QiskitOpt.jl. This is intended for
+pass-manager recipes developed with upstream tooling such as
+`qiskit-community/qopt-best-practices`; QiskitOpt.jl does not add those tools as
+dependencies.
+
+```julia
+function hardware_aware_qaoa_pass_manager(
+    backend;
+    optimization_level=3,
+    seed_transpiler=nothing,
+)
+    return QiskitOpt.preset_pass_manager(
+        backend;
+        optimization_level=optimization_level,
+        seed_transpiler=seed_transpiler,
+    )
+end
+
+set_attribute(
+    model,
+    QiskitOpt.QAOA.PassManagerFactory(),
+    hardware_aware_qaoa_pass_manager,
+)
+```
+
+The factory receives the selected backend and may accept `optimization_level`
+and `seed_transpiler` keywords. `TranspilerSeed()` is forwarded as
+`seed_transpiler` when the callable supports it. QiskitOpt.jl uses the returned
+pass manager for both the optimization ansatz and the final measured circuit.
+Result metadata records whether QAOA used the default preset pass manager or a
+custom factory. VQE does not expose this QAOA-specific hook.
+
 ## Upstream Boundary
 
 QiskitOpt.jl should remain the JuMP/MOI adapter that sends a QUBO to Qiskit,
@@ -167,7 +204,7 @@ samples. Broader QAOA research workflows belong upstream:
 
 | Belongs in QiskitOpt.jl | Belongs upstream |
 | --- | --- |
-| `IBMBackend()`, `IsLocal()`, `IBMFakeBackend()`, Aer attributes, and seeds | Hardware-aware transpilation recipes from `qopt-best-practices` |
+| `IBMBackend()`, `IsLocal()`, `IBMFakeBackend()`, `PassManagerFactory()`, Aer attributes, and seeds | Hardware-aware transpilation recipe development from `qopt-best-practices` |
 | `InitialParameters()` and `InitialParameterSource()` | MPS, Pauli propagation, parameter-transfer, and schedule-training pipelines |
 | Result metadata for backend configuration, seeds, and starting angles | SAT mapping, SWAP strategies, qubit selection, and CVaR/top-tail sample-objective training loops |
 

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -64,6 +64,7 @@ QUBODrivers.@setup Optimizer begin
         AerMPSSampleMeasureAlgorithm["aer_mps_sample_measure_algorithm"]::Union{String, Nothing} = nothing
         AerSeedSimulator["aer_seed_simulator"]::Union{Integer, Nothing} = nothing
         TranspilerSeed["transpiler_seed"]::Union{Integer, Nothing} = nothing
+        PassManagerFactory["pass_manager_factory"] = nothing
         Channel["channel"]::Union{String, Nothing} = nothing
         Instance["instance"]::Union{String, Nothing} = nothing
     end
@@ -96,6 +97,87 @@ function _fixed_angle_record(number_of_layers::Integer, family::Symbol)
     end
 
     return _WURTZ_LYKOV_3REGULAR_TREE_ANGLES[p]
+end
+
+function _pass_manager_factory_signature_mismatch(err, factory)
+    return err isa MethodError &&
+        (
+            (
+                err.f === Core.kwcall &&
+                length(err.args) >= 2 &&
+                err.args[2] === factory
+            ) ||
+            err.f === factory
+        )
+end
+
+function _try_pass_manager_factory(call::Function, factory)
+    try
+        return (pass_manager = call(), matched = true)
+    catch err
+        _pass_manager_factory_signature_mismatch(err, factory) || rethrow()
+        return (pass_manager = nothing, matched = false)
+    end
+end
+
+function _custom_pass_manager(
+    factory,
+    backend;
+    optimization_level::Integer,
+    seed_transpiler,
+)
+    attempts = (
+        () -> factory(
+            backend;
+            optimization_level=optimization_level,
+            seed_transpiler=seed_transpiler,
+        ),
+        () -> factory(backend; optimization_level=optimization_level),
+        () -> factory(backend; seed_transpiler=seed_transpiler),
+        () -> factory(backend),
+    )
+
+    for attempt in attempts
+        result = _try_pass_manager_factory(attempt, factory)
+        result.matched && return result.pass_manager
+    end
+
+    throw(
+        ArgumentError(
+            "QAOA.PassManagerFactory must accept the selected backend and may " *
+            "optionally accept optimization_level and seed_transpiler keywords",
+        ),
+    )
+end
+
+function _selected_pass_manager(
+    backend;
+    factory = nothing,
+    optimization_level::Integer = 3,
+    seed_transpiler = nothing,
+)
+    if isnothing(factory)
+        return (
+            pass_manager = preset_pass_manager(
+                backend;
+                optimization_level=optimization_level,
+                seed_transpiler=seed_transpiler,
+            ),
+            source = "default_preset",
+            optimization_level = optimization_level,
+        )
+    end
+
+    return (
+        pass_manager = _custom_pass_manager(
+            factory,
+            backend;
+            optimization_level=optimization_level,
+            seed_transpiler=seed_transpiler,
+        ),
+        source = "custom_factory",
+        optimization_level = optimization_level,
+    )
 end
 
 """
@@ -295,6 +377,7 @@ function retrieve(
     initial_parameter_source = MOI.get(sampler, QAOA.InitialParameterSource())
     record_initial_parameters = MOI.get(sampler, QAOA.RecordInitialParameters())
     is_local         = MOI.get(sampler, QAOA.IsLocal())
+    pass_manager_factory = MOI.get(sampler, QAOA.PassManagerFactory())
     aer_config = AerBackendConfig(
         method=MOI.get(sampler, QAOA.AerBackendMethod()),
         precision=MOI.get(sampler, QAOA.AerPrecision()),
@@ -348,11 +431,13 @@ function retrieve(
     execution_mode = backend_selection.execution_mode
     backend_label = backend_name(backend)
 
-    pass_manager = preset_pass_manager(
+    pass_manager_selection = _selected_pass_manager(
         backend;
+        factory=pass_manager_factory,
         optimization_level=3,
         seed_transpiler=aer_config.seed_transpiler,
     )
+    pass_manager = pass_manager_selection.pass_manager
     
     ansatz_isa = pass_manager.run(ansatz)
     ising_hamiltonian = ising_hamiltonian.apply_layout(layout=ansatz_isa.layout)
@@ -389,6 +474,8 @@ function retrieve(
         backend_config=backend_selection.config,
         backend_config_source=backend_selection.source,
         seed_transpiler=aer_config.seed_transpiler,
+        pass_manager_source=pass_manager_selection.source,
+        pass_manager_optimization_level=pass_manager_selection.optimization_level,
         initial_parameters=record_initial_parameters ? initial_parameter_values : nothing,
         initial_parameter_names=record_initial_parameters ? parameter_names : nothing,
         initial_parameter_source=record_initial_parameters ? initial_parameter_source : nothing,

--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -666,6 +666,8 @@ function empty_metadata(
     backend_config::Union{AerBackendConfig,Nothing} = nothing,
     backend_config_source::Union{AbstractString,Nothing} = nothing,
     seed_transpiler = nothing,
+    pass_manager_source::Union{AbstractString,Nothing} = nothing,
+    pass_manager_optimization_level::Union{Integer,Nothing} = nothing,
     initial_parameters::Union{AbstractVector,Nothing} = nothing,
     initial_parameter_names::Union{AbstractVector{<:AbstractString},Nothing} = nothing,
     initial_parameter_source::Union{AbstractString,Nothing} = nothing,
@@ -693,6 +695,14 @@ function empty_metadata(
             seed_simulator=seed_simulator,
             seed_transpiler=seed_transpiler,
         )
+    end
+
+    if !isnothing(pass_manager_source)
+        pass_manager_metadata = Dict{String,Any}("source" => String(pass_manager_source))
+        if !isnothing(pass_manager_optimization_level)
+            pass_manager_metadata["optimization_level"] = pass_manager_optimization_level
+        end
+        metadata["pass_manager"] = pass_manager_metadata
     end
 
     if !isnothing(initial_parameters)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -596,7 +596,60 @@ end
         @test metadata["initial_parameters"]["source"] == initial_parameter_source
         @test metadata["initial_parameters"]["parameter_names"] == initial_parameter_names
         @test metadata["initial_parameters"]["values"] == initial_parameters
+        if optimizer_module === QAOA
+            @test metadata["pass_manager"]["source"] == "default_preset"
+            @test metadata["pass_manager"]["optimization_level"] == 3
+        else
+            @test !haskey(metadata, "pass_manager")
+        end
     end
+end
+
+@testset "QAOA custom pass-manager factory" begin
+    factory_calls = NamedTuple[]
+    pass_manager_runs = Ref(0)
+
+    function factory(backend; optimization_level=3, seed_transpiler=nothing)
+        push!(
+            factory_calls,
+            (
+                backend=backend,
+                optimization_level=optimization_level,
+                seed_transpiler=seed_transpiler,
+            ),
+        )
+        inner = QiskitOpt.preset_pass_manager(
+            backend;
+            optimization_level=optimization_level,
+            seed_transpiler=seed_transpiler,
+        )
+        return (
+            run = circuit -> begin
+                pass_manager_runs[] += 1
+                return inner.run(circuit)
+            end,
+        )
+    end
+
+    sampleset = sample_locally_without_runtime_service(
+        QAOA.Optimizer,
+        QAOA,
+        (model, module_) -> begin
+            MOI.set(model, module_.PassManagerFactory(), factory)
+            MOI.set(model, module_.TranspilerSeed(), 4321)
+        end;
+        max_iterations=1,
+        number_of_reads=16,
+    )
+    metadata = QUBOTools.metadata(sampleset)
+
+    @test length(factory_calls) == 1
+    @test factory_calls[1].optimization_level == 3
+    @test factory_calls[1].seed_transpiler == 4321
+    @test pass_manager_runs[] == 2
+    @test metadata["pass_manager"]["source"] == "custom_factory"
+    @test metadata["pass_manager"]["optimization_level"] == 3
+    @test !isdefined(VQE, :PassManagerFactory)
 end
 
 @testset "Final sampling reads use generic QUBODrivers attribute" begin


### PR DESCRIPTION
## Summary

- Add `QAOA.PassManagerFactory()` as an opt-in QAOA-only pass-manager hook.
- Use the selected pass manager for both QAOA ansatz transpilation and final measured-circuit transpilation.
- Record whether QAOA used the default preset pass manager or a custom factory in result metadata.
- Document the hook in the README and QAOA best-practices guide.

## Tests

- `git diff --check HEAD~1 HEAD`
- `julia --project=. -e 'using Pkg; Pkg.test()'`

## Notes

- VQE does not expose `PassManagerFactory()`.
- No new Python dependency is introduced.

Closes #35
