### PR TITLE
[codex] Expose QUBODrivers seed metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,10 @@ set_attribute(model, QAOA.TranspilerSeed(), 73001)
 
 The returned `SampleSet` metadata records the selected backend configuration,
 standard sampler seed, derived or explicit simulator/transpiler seeds, final
-read count, optimizer iteration/evaluation counts, and backend name/version. If
-you need complete control, the existing backend-factory override remains
+read count, optimizer iteration/evaluation counts, and structured backend
+name/version under `metadata["backend"]`. A scalar `metadata["backend_name"]`
+alias is also recorded for scripts that only need the backend label. If you
+need complete control, the existing backend-factory override remains
 available:
 
 ```julia

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ set_attribute(model, QiskitOpt.QUBODrivers.FinalNumberOfReads(), 8192)
 # Maximum optimizer iterations
 set_attribute(model, VQE.MaximumIterations(), 100) # or QAOA.MaximumIterations
 
+# Standard benchmark seed. When algorithm-specific seeds are unset, QiskitOpt
+# deterministically derives the local Aer and transpiler seeds from this value.
+set_attribute(model, QiskitOpt.QUBODrivers.RandomSeed(), 73001)
+
 # Ansatz
 set_attribute(model, VQE.Ansatz(), QiskitOpt.qiskit.circuit.library.EfficientSU2)
 
@@ -167,7 +171,11 @@ set_attribute(model, QAOA.AerSeedSimulator(), 73001)
 set_attribute(model, QAOA.TranspilerSeed(), 73001)
 ```
 
-The returned `SampleSet` metadata records the selected backend configuration and simulator/transpiler seeds. If you need complete control, the existing backend-factory override remains available:
+The returned `SampleSet` metadata records the selected backend configuration,
+standard sampler seed, derived or explicit simulator/transpiler seeds, final
+read count, optimizer iteration/evaluation counts, and backend name/version. If
+you need complete control, the existing backend-factory override remains
+available:
 
 ```julia
 set_attribute(

--- a/docs/qaoa_best_practices.md
+++ b/docs/qaoa_best_practices.md
@@ -34,6 +34,7 @@ configuration is stable.
 | Initial angle values | `QiskitOpt.QAOA.InitialParameters()` |
 | Initial angle provenance | `QiskitOpt.QAOA.InitialParameterSource()` |
 | Initial metadata recording | `QiskitOpt.QAOA.RecordInitialParameters()` |
+| Standard benchmark seed | `QiskitOpt.QUBODrivers.RandomSeed()` |
 | Local Aer method | `QiskitOpt.QAOA.AerBackendMethod()` |
 | Local Aer precision | `QiskitOpt.QAOA.AerPrecision()` |
 | Local Aer simulator seed | `QiskitOpt.QAOA.AerSeedSimulator()` |
@@ -60,10 +61,16 @@ set_attribute(model, QiskitOpt.QAOA.NumberOfReads(), 1024)
 set_attribute(model, QiskitOpt.QUBODrivers.FinalNumberOfReads(), 8192)
 set_attribute(model, QiskitOpt.QAOA.MaximumIterations(), 100)
 
+set_attribute(model, QiskitOpt.QUBODrivers.RandomSeed(), 73001)
 set_attribute(model, QiskitOpt.QAOA.AerBackendMethod(), "matrix_product_state")
 set_attribute(model, QiskitOpt.QAOA.AerSeedSimulator(), 73001)
 set_attribute(model, QiskitOpt.QAOA.TranspilerSeed(), 73001)
 ```
+
+`QUBODrivers.RandomSeed()` is the benchmark-facing seed. If
+`AerSeedSimulator()` or `TranspilerSeed()` is unset, QiskitOpt derives that
+Qiskit-specific seed deterministically from the standard seed. Explicit
+QiskitOpt seed attributes still take precedence.
 
 ## Initial Parameters
 

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -4,10 +4,13 @@ using PythonCall: pyconvert, pylist, pydict, pyint, @pyexec
 using ..QiskitOpt:
     AerBackendConfig,
     backend_name,
+    backend_version,
     configured_execution_backend,
     default_local_backend,
+    effective_seed,
     empty_metadata,
     preset_pass_manager,
+    python_int_property,
     qiskit_parameter_names,
     qiskit,
     qiskit_ibm_runtime,
@@ -49,6 +52,7 @@ QUBODrivers.@setup Optimizer begin
         MaximumIterations["max_iter"]::Integer     = 15
         NumberOfReads["num_reads"]::Integer        = 100
         NumberOfLayers["num_layers"]::Integer      = 1
+        RandomSeed["seed"]::Union{Integer, Nothing} = nothing
         InitialParameters["initial_parameters"]::Union{Vector{Float64}, Nothing} = nothing 
         InitialParameterSource["initial_parameter_source"]::Union{String, Nothing} = nothing
         RecordInitialParameters["record_initial_parameters"]::Bool = true
@@ -69,6 +73,8 @@ QUBODrivers.@setup Optimizer begin
         Instance["instance"]::Union{String, Nothing} = nothing
     end
 end
+
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = true
 
 function _check_number_of_layers(number_of_layers::Integer)
     number_of_layers >= 1 || throw(ArgumentError("number_of_layers must be at least 1"))
@@ -342,7 +348,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     # Results vector
     samples = QUBOTools.Sample{T,Int}[]
 
-    metadata = retrieve(sampler) do _, sample_results
+    retrieve_results = @timed retrieve(sampler) do _, sample_results
         for key in sample_results.keys()
             state = sample_bits(key)
             objective_value = QUBOTools.value(state, L, Q, α, β)
@@ -356,6 +362,8 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
 
         return nothing
     end
+    metadata = retrieve_results.value
+    metadata["time"]["effective"] = retrieve_results.time
 
     return SampleSet{T}(samples, metadata)
 end
@@ -369,6 +377,7 @@ function retrieve(
     num_reads       = MOI.get(sampler, QAOA.NumberOfReads())
     final_num_reads = MOI.get(sampler, QUBODrivers.FinalNumberOfReads())
     num_layers      = MOI.get(sampler, QAOA.NumberOfLayers())
+    sampler_seed    = MOI.get(sampler, QUBODrivers.RandomSeed())
     ibm_backend     = MOI.get(sampler, QAOA.IBMBackend())
     ibm_fake_backend = MOI.get(sampler, QAOA.IBMFakeBackend())
     channel         = runtime_channel(MOI.get(sampler, QAOA.Channel()))
@@ -378,6 +387,8 @@ function retrieve(
     record_initial_parameters = MOI.get(sampler, QAOA.RecordInitialParameters())
     is_local         = MOI.get(sampler, QAOA.IsLocal())
     pass_manager_factory = MOI.get(sampler, QAOA.PassManagerFactory())
+    seed_simulator = effective_seed(MOI.get(sampler, QAOA.AerSeedSimulator()), sampler_seed, 1)
+    seed_transpiler = effective_seed(MOI.get(sampler, QAOA.TranspilerSeed()), sampler_seed, 2)
     aer_config = AerBackendConfig(
         method=MOI.get(sampler, QAOA.AerBackendMethod()),
         precision=MOI.get(sampler, QAOA.AerPrecision()),
@@ -386,8 +397,8 @@ function retrieve(
         mps_truncation_threshold=MOI.get(sampler, QAOA.AerMPSTruncationThreshold()),
         mps_max_bond_dimension=MOI.get(sampler, QAOA.AerMPSMaxBondDimension()),
         mps_sample_measure_algorithm=MOI.get(sampler, QAOA.AerMPSSampleMeasureAlgorithm()),
-        seed_simulator=MOI.get(sampler, QAOA.AerSeedSimulator()),
-        seed_transpiler=MOI.get(sampler, QAOA.TranspilerSeed()),
+        seed_simulator=seed_simulator,
+        seed_transpiler=seed_transpiler,
     )
 
     ising_qp = quadratic_program(sampler)
@@ -430,6 +441,7 @@ function retrieve(
     backend = backend_selection.backend
     execution_mode = backend_selection.execution_mode
     backend_label = backend_name(backend)
+    backend_release = backend_version(backend)
 
     pass_manager_selection = _selected_pass_manager(
         backend;
@@ -471,9 +483,17 @@ function retrieve(
         "QAOA",
         backend_label,
         execution_mode;
+        backend_version=backend_release,
         backend_config=backend_selection.config,
         backend_config_source=backend_selection.source,
+        number_of_reads=final_num_reads,
+        final_number_of_reads=final_num_reads,
+        optimizer_iterations=python_int_property(result, :nit),
+        optimizer_evaluations=python_int_property(result, :nfev),
+        optimizer_number_of_reads=num_reads,
+        seed_sampler=sampler_seed,
         seed_transpiler=aer_config.seed_transpiler,
+        seed_optimizer=nothing,
         pass_manager_source=pass_manager_selection.source,
         pass_manager_optimization_level=pass_manager_selection.optimization_level,
         initial_parameters=record_initial_parameters ? initial_parameter_values : nothing,

--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -551,8 +551,29 @@ function backend_name(backend)
     end
 end
 
+function python_type_module(object)
+    try
+        return PythonCall.pyconvert(
+            String,
+            getproperty(getproperty(object, :__class__), :__module__),
+        )
+    catch
+        return nothing
+    end
+end
+
+function is_qiskit_aer_backend(backend)
+    module_name = python_type_module(backend)
+    return !isnothing(module_name) && startswith(module_name, "qiskit_aer")
+end
+
 function backend_version(backend)
-    for property in (:version, :backend_version)
+    if is_qiskit_aer_backend(backend)
+        aer_version = _python_module_version(qiskit_aer())
+        !isnothing(aer_version) && return aer_version
+    end
+
+    for property in (:backend_version, :version)
         try
             return PythonCall.pyconvert(String, PythonCall.pystr(getproperty(backend, property)))
         catch
@@ -560,6 +581,17 @@ function backend_version(backend)
     end
 
     return nothing
+end
+
+function execution_status(execution_mode::AbstractString)
+    mode = String(execution_mode)
+    if mode == "local"
+        return "locally_solved"
+    elseif mode == "cloud"
+        return "cloud_solved"
+    end
+
+    return "$(mode)_solved"
 end
 
 function sample_bits(key)
@@ -726,6 +758,7 @@ function empty_metadata(
         "algorithm" => Dict{String,Any}(
             "name" => String(algorithm),
         ),
+        "backend_name" => String(backend),
         "backend" => Dict{String,Any}(
             "name" => String(backend),
             "version" => backend_version,
@@ -751,7 +784,7 @@ function empty_metadata(
             seed_transpiler=seed_transpiler,
             seed_optimizer=seed_optimizer,
         ),
-        "status" => "locally_solved",
+        "status" => execution_status(execution_mode),
     )
 
     if !isnothing(backend_config) || !isnothing(backend_config_source)

--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -551,6 +551,17 @@ function backend_name(backend)
     end
 end
 
+function backend_version(backend)
+    for property in (:version, :backend_version)
+        try
+            return PythonCall.pyconvert(String, PythonCall.pystr(getproperty(backend, property)))
+        catch
+        end
+    end
+
+    return nothing
+end
+
 function sample_bits(key)
     bitstring = replace(PythonCall.pyconvert(String, key), " " => "")
     return reverse(Int[(digit == '1') for digit in bitstring])
@@ -570,13 +581,18 @@ function aer_backend_metadata(config::AerBackendConfig, source::AbstractString)
 end
 
 function seed_metadata(;
+    seed_sampler = nothing,
     seed_simulator = nothing,
     seed_transpiler = nothing,
+    seed_optimizer = nothing,
 )
-    return Dict{String,Any}(
+    seeds = Dict{String,Any}(
         "simulator" => seed_simulator,
         "transpiler" => seed_transpiler,
+        "optimizer" => seed_optimizer,
     )
+    isnothing(seed_sampler) || (seeds["sampler"] = seed_sampler)
+    return seeds
 end
 
 function _seed_state(seed::Integer)
@@ -622,6 +638,31 @@ function random_unit_values(count::Integer; seed = nothing, rng = nothing)
     return rand(Float64, count)
 end
 
+function derived_seed(seed::Union{Integer,Nothing}, stream::Integer)
+    isnothing(seed) && return nothing
+    stream >= 1 || throw(ArgumentError("seed stream must be at least 1"))
+
+    state = _seed_state(seed)
+    value = UInt64(0)
+    for _ in 1:stream
+        state, value = _splitmix64_next(state)
+    end
+
+    return Int(mod(BigInt(value), BigInt(typemax(Int32))))
+end
+
+function effective_seed(explicit_seed, sampler_seed::Union{Integer,Nothing}, stream::Integer)
+    return isnothing(explicit_seed) ? derived_seed(sampler_seed, stream) : explicit_seed
+end
+
+function python_int_property(object, name::Symbol)
+    try
+        return PythonCall.pyconvert(Int, getproperty(object, name))
+    catch
+        return nothing
+    end
+end
+
 function qiskit_parameter_names(circuit)
     return String[
         PythonCall.pyconvert(String, PythonCall.pystr(parameter))
@@ -663,9 +704,17 @@ function empty_metadata(
     algorithm::AbstractString,
     backend::AbstractString,
     execution_mode::AbstractString;
+    backend_version = nothing,
     backend_config::Union{AerBackendConfig,Nothing} = nothing,
     backend_config_source::Union{AbstractString,Nothing} = nothing,
+    number_of_reads::Union{Integer,Nothing} = nothing,
+    final_number_of_reads::Union{Integer,Nothing} = number_of_reads,
+    optimizer_iterations = nothing,
+    optimizer_evaluations = nothing,
+    optimizer_number_of_reads = nothing,
+    seed_sampler = nothing,
     seed_transpiler = nothing,
+    seed_optimizer = nothing,
     pass_manager_source::Union{AbstractString,Nothing} = nothing,
     pass_manager_optimization_level::Union{Integer,Nothing} = nothing,
     initial_parameters::Union{AbstractVector,Nothing} = nothing,
@@ -674,10 +723,35 @@ function empty_metadata(
 )
     metadata = Dict{String,Any}(
         "origin" => "$(algorithm) @ $(backend)",
-        "backend" => backend,
+        "algorithm" => Dict{String,Any}(
+            "name" => String(algorithm),
+        ),
+        "backend" => Dict{String,Any}(
+            "name" => String(backend),
+            "version" => backend_version,
+        ),
+        "execution" => Dict{String,Any}(
+            "mode" => String(execution_mode),
+        ),
         "execution_mode" => execution_mode,
+        "optimizer" => Dict{String,Any}(
+            "iterations" => optimizer_iterations,
+            "evaluations" => optimizer_evaluations,
+            "number_of_reads" => optimizer_number_of_reads,
+        ),
+        "reads" => Dict{String,Any}(
+            "number_of_reads" => final_number_of_reads,
+            "final_number_of_reads" => final_number_of_reads,
+        ),
         "time" => Dict{String,Any}(),
         "evals" => Float64[],
+        "seeds" => seed_metadata(
+            seed_sampler=seed_sampler,
+            seed_simulator=isnothing(backend_config) ? nothing : backend_config.seed_simulator,
+            seed_transpiler=seed_transpiler,
+            seed_optimizer=seed_optimizer,
+        ),
+        "status" => "locally_solved",
     )
 
     if !isnothing(backend_config) || !isnothing(backend_config_source)
@@ -687,14 +761,6 @@ function empty_metadata(
         else
             aer_backend_metadata(backend_config, source)
         end
-    end
-
-    if !isnothing(backend_config) || !isnothing(seed_transpiler)
-        seed_simulator = isnothing(backend_config) ? nothing : backend_config.seed_simulator
-        metadata["seeds"] = seed_metadata(
-            seed_simulator=seed_simulator,
-            seed_transpiler=seed_transpiler,
-        )
     end
 
     if !isnothing(pass_manager_source)

--- a/src/VQE.jl
+++ b/src/VQE.jl
@@ -4,10 +4,13 @@ using PythonCall: pyconvert, pylist, pydict, pyint, @pyexec
 using ..QiskitOpt:
     AerBackendConfig,
     backend_name,
+    backend_version,
     configured_execution_backend,
     default_local_backend,
+    effective_seed,
     empty_metadata,
     preset_pass_manager,
+    python_int_property,
     qiskit_parameter_names,
     qiskit,
     qiskit_ibm_runtime,
@@ -34,6 +37,7 @@ QUBODrivers.@setup Optimizer begin
     attributes = begin
         MaximumIterations["max_iter"]::Integer     = 15
         NumberOfReads["num_reads"]::Integer        = 100
+        RandomSeed["seed"]::Union{Integer, Nothing} = nothing
         InitialParameters["initial_parameters"]::Union{Vector{Float64}, Nothing} = nothing 
         InitialParameterSource["initial_parameter_source"]::Union{String, Nothing} = nothing
         RecordInitialParameters["record_initial_parameters"]::Bool = true
@@ -54,6 +58,8 @@ QUBODrivers.@setup Optimizer begin
         Ansatz["ansatz"]                           = default_ansatz
     end
 end
+
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = true
 
 function _check_n_variables(n_variables::Integer)
     n_variables >= 1 || throw(ArgumentError("n_variables must be at least 1"))
@@ -126,7 +132,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     # Results vector
     samples = QUBOTools.Sample{T,Int}[]
 
-    metadata = retrieve(sampler) do _, sample_results
+    retrieve_results = @timed retrieve(sampler) do _, sample_results
         for key in sample_results.keys()
             state = sample_bits(key)
             objective_value = QUBOTools.value(state, L, Q, α, β)
@@ -140,6 +146,8 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
 
         return nothing
     end
+    metadata = retrieve_results.value
+    metadata["time"]["effective"] = retrieve_results.time
 
     return SampleSet{T}(samples, metadata)
 end
@@ -152,6 +160,7 @@ function retrieve(
     max_iter        = MOI.get(sampler, VQE.MaximumIterations())
     num_reads       = MOI.get(sampler, VQE.NumberOfReads())
     final_num_reads = MOI.get(sampler, QUBODrivers.FinalNumberOfReads())
+    sampler_seed    = MOI.get(sampler, QUBODrivers.RandomSeed())
     ibm_backend     = MOI.get(sampler, VQE.IBMBackend())
     ibm_fake_backend = MOI.get(sampler, VQE.IBMFakeBackend())
     ansatz_instance = MOI.get(sampler, VQE.Ansatz())
@@ -161,6 +170,8 @@ function retrieve(
     initial_parameter_source = MOI.get(sampler, VQE.InitialParameterSource())
     record_initial_parameters = MOI.get(sampler, VQE.RecordInitialParameters())
     is_local         = MOI.get(sampler, VQE.IsLocal())
+    seed_simulator = effective_seed(MOI.get(sampler, VQE.AerSeedSimulator()), sampler_seed, 1)
+    seed_transpiler = effective_seed(MOI.get(sampler, VQE.TranspilerSeed()), sampler_seed, 2)
     aer_config = AerBackendConfig(
         method=MOI.get(sampler, VQE.AerBackendMethod()),
         precision=MOI.get(sampler, VQE.AerPrecision()),
@@ -169,8 +180,8 @@ function retrieve(
         mps_truncation_threshold=MOI.get(sampler, VQE.AerMPSTruncationThreshold()),
         mps_max_bond_dimension=MOI.get(sampler, VQE.AerMPSMaxBondDimension()),
         mps_sample_measure_algorithm=MOI.get(sampler, VQE.AerMPSSampleMeasureAlgorithm()),
-        seed_simulator=MOI.get(sampler, VQE.AerSeedSimulator()),
-        seed_transpiler=MOI.get(sampler, VQE.TranspilerSeed()),
+        seed_simulator=seed_simulator,
+        seed_transpiler=seed_transpiler,
     )
 
     ising_qp = quadratic_program(sampler)
@@ -211,6 +222,7 @@ function retrieve(
     backend = backend_selection.backend
     execution_mode = backend_selection.execution_mode
     backend_label = backend_name(backend)
+    backend_release = backend_version(backend)
 
     pass_manager = preset_pass_manager(
         backend;
@@ -250,9 +262,17 @@ function retrieve(
         "VQE",
         backend_label,
         execution_mode;
+        backend_version=backend_release,
         backend_config=backend_selection.config,
         backend_config_source=backend_selection.source,
+        number_of_reads=final_num_reads,
+        final_number_of_reads=final_num_reads,
+        optimizer_iterations=python_int_property(result, :nit),
+        optimizer_evaluations=python_int_property(result, :nfev),
+        optimizer_number_of_reads=num_reads,
+        seed_sampler=sampler_seed,
         seed_transpiler=aer_config.seed_transpiler,
+        seed_optimizer=nothing,
         initial_parameters=record_initial_parameters ? initial_parameter_values : nothing,
         initial_parameter_names=record_initial_parameters ? parameter_names : nothing,
         initial_parameter_source=record_initial_parameters ? initial_parameter_source : nothing,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -382,15 +382,36 @@ end
         "QAOA",
         "aer_simulator",
         "local";
+        backend_version="0.17.0",
         backend_config=custom_config,
         backend_config_source="aer_attributes",
+        number_of_reads=48,
+        optimizer_iterations=2,
+        optimizer_evaluations=3,
+        optimizer_number_of_reads=16,
         seed_transpiler=5678,
     )
+    metadata["time"]["effective"] = 1.0e-6
+    metadata["time"]["total"] = 2.0e-6
+    @test QUBODrivers.validate_metadata(metadata) == String[]
+    @test metadata["algorithm"]["name"] == "QAOA"
+    @test metadata["backend"]["name"] == "aer_simulator"
+    @test metadata["backend"]["version"] == "0.17.0"
+    @test metadata["execution"]["mode"] == "local"
+    @test metadata["reads"]["number_of_reads"] == 48
+    @test metadata["reads"]["final_number_of_reads"] == 48
+    @test metadata["optimizer"]["iterations"] == 2
+    @test metadata["optimizer"]["evaluations"] == 3
+    @test metadata["optimizer"]["number_of_reads"] == 16
     @test metadata["backend_configuration"]["source"] == "aer_attributes"
     @test metadata["backend_configuration"]["method"] == "statevector"
     @test metadata["backend_configuration"]["precision"] == "single"
     @test metadata["seeds"]["simulator"] == 1234
     @test metadata["seeds"]["transpiler"] == 5678
+    @test metadata["seeds"]["optimizer"] === nothing
+
+    @test QiskitOpt.effective_seed(nothing, 73001, 1) == QiskitOpt.derived_seed(73001, 1)
+    @test QiskitOpt.effective_seed(999, 73001, 1) == 999
 
     opaque_metadata = QiskitOpt.empty_metadata(
         "QAOA",
@@ -569,6 +590,7 @@ end
             VQE.parameter_names(n_variables=3)
         end
         initial_parameter_source = optimizer_module === QAOA ? QAOA.FIXED_ANGLE_SOURCE : "random_seed_73001"
+        number_of_reads = 16
 
         sampleset = sample_locally_without_runtime_service(
             optimizer_factory,
@@ -582,11 +604,23 @@ end
                 MOI.set(model, module_.InitialParameterSource(), initial_parameter_source)
             end;
             max_iterations=1,
-            number_of_reads=16,
+            number_of_reads=number_of_reads,
         )
         metadata = QUBOTools.metadata(sampleset)
         @test startswith(metadata["origin"], "$(algorithm) @ ")
         @test metadata["execution_mode"] == "local"
+        @test metadata["execution"]["mode"] == "local"
+        @test metadata["algorithm"]["name"] == algorithm
+        @test metadata["backend"] isa Dict{String,Any}
+        @test metadata["backend"]["name"] isa String
+        @test haskey(metadata["backend"], "version")
+        @test metadata["reads"]["number_of_reads"] == number_of_reads
+        @test metadata["reads"]["final_number_of_reads"] == number_of_reads
+        @test metadata["optimizer"]["number_of_reads"] == number_of_reads
+        @test metadata["optimizer"]["evaluations"] isa Union{Integer,Nothing}
+        @test metadata["time"]["effective"] > 0
+        @test metadata["time"]["total"] > 0
+        @test QUBODrivers.validate_metadata(metadata) == String[]
         @test metadata["backend_configuration"]["source"] == "aer_attributes"
         @test metadata["backend_configuration"]["method"] == "matrix_product_state"
         @test metadata["backend_configuration"]["precision"] == "single"
@@ -602,6 +636,33 @@ end
         else
             @test !haskey(metadata, "pass_manager")
         end
+    end
+end
+
+@testset "Standard QUBODrivers RandomSeed is recorded and overridden explicitly" begin
+    for (optimizer_factory, optimizer_module) in ((QAOA.Optimizer, QAOA), (VQE.Optimizer, VQE))
+        sampler = optimizer_factory()
+        @test MOI.supports(sampler, QUBODrivers.RandomSeed())
+        @test QUBODrivers.supports_seed(typeof(sampler))
+        MOI.set(sampler, QUBODrivers.RandomSeed(), 73001)
+        @test MOI.get(sampler, QUBODrivers.RandomSeed()) == 73001
+
+        sampleset = sample_locally_without_runtime_service(
+            optimizer_factory,
+            optimizer_module,
+            (model, module_) -> begin
+                MOI.set(model, QUBODrivers.RandomSeed(), 73001)
+                MOI.set(model, module_.AerSeedSimulator(), 1234)
+                MOI.set(model, module_.TranspilerSeed(), 5678)
+            end;
+            max_iterations=1,
+            number_of_reads=8,
+        )
+        metadata = QUBOTools.metadata(sampleset)
+
+        @test metadata["seeds"]["sampler"] == 73001
+        @test metadata["seeds"]["simulator"] == 1234
+        @test metadata["seeds"]["transpiler"] == 5678
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -377,6 +377,9 @@ end
         seed_transpiler=5678,
     )
     @test !isnothing(QiskitOpt.local_aer_backend(smoke_config))
+    @test QiskitOpt.backend_version(QiskitOpt.default_local_backend()) ==
+          QiskitOpt._python_module_version(QiskitOpt.qiskit_aer())
+    @test QiskitOpt.backend_version(QiskitOpt.default_local_backend()) != "2"
 
     metadata = QiskitOpt.empty_metadata(
         "QAOA",
@@ -395,9 +398,11 @@ end
     metadata["time"]["total"] = 2.0e-6
     @test QUBODrivers.validate_metadata(metadata) == String[]
     @test metadata["algorithm"]["name"] == "QAOA"
+    @test metadata["backend_name"] == "aer_simulator"
     @test metadata["backend"]["name"] == "aer_simulator"
     @test metadata["backend"]["version"] == "0.17.0"
     @test metadata["execution"]["mode"] == "local"
+    @test metadata["status"] == "locally_solved"
     @test metadata["reads"]["number_of_reads"] == 48
     @test metadata["reads"]["final_number_of_reads"] == 48
     @test metadata["optimizer"]["iterations"] == 2
@@ -426,6 +431,12 @@ end
     @test !haskey(opaque_metadata["backend_configuration"], "method")
     @test opaque_metadata["seeds"]["simulator"] === nothing
     @test opaque_metadata["seeds"]["transpiler"] == 5678
+
+    cloud_metadata = QiskitOpt.empty_metadata("QAOA", "ibm_backend", "cloud"; number_of_reads=48)
+    cloud_metadata["time"]["effective"] = 1.0e-6
+    cloud_metadata["time"]["total"] = 2.0e-6
+    @test QUBODrivers.validate_metadata(cloud_metadata) == String[]
+    @test cloud_metadata["status"] == "cloud_solved"
 
     factory = QiskitOpt.local_aer_backend_factory(custom_config)
     @test factory.config.seed_simulator == 1234
@@ -611,6 +622,7 @@ end
         @test metadata["execution_mode"] == "local"
         @test metadata["execution"]["mode"] == "local"
         @test metadata["algorithm"]["name"] == algorithm
+        @test metadata["backend_name"] == metadata["backend"]["name"]
         @test metadata["backend"] isa Dict{String,Any}
         @test metadata["backend"]["name"] isa String
         @test haskey(metadata["backend"], "version")


### PR DESCRIPTION
## Summary

- Add standard `QUBODrivers.RandomSeed()` support to QAOA and VQE.
- Derive Aer simulator and transpiler seeds from the standard sampler seed when explicit QiskitOpt seed attributes are unset.
- Emit QUBODrivers benchmarking metadata for algorithm, backend, reads, optimizer, seeds, and effective time.
- Extend tests for metadata conformance, seed override behavior, and the QUBODrivers compatibility suite.
- Document the benchmark-facing seed behavior in the README and QAOA guide.

## Tests

- `julia +release --project=. -e 'using Pkg; Pkg.test()'`
  - Passed.

## Branch Hygiene

- Base branch: `main`.
- Source branch: `fix/issue-43-qubodrivers-samplers`.
- Source branch point: `c95e438f3f31864397b03603a8da67241bb8c1b6` (`origin/main` at branch creation).
- Stacked status: not stacked.
- Prerequisite PRs: none.

Closes #43.
