### PR TITLE
Release v0.5.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QiskitOpt"
 uuid = "81b20daf-e62b-4502-a0d1-aa084de80e33"
 authors = ["pedromxavier <pedroxavier@psr-inc.com>", "pedroripper <pedroripper@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.4.2"
+version = "0.5.0"
 
 [deps]
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"


### PR DESCRIPTION
## Summary

- bump QiskitOpt.jl version from 0.4.2 to 0.5.0
- publish the QUBODrivers-compatible QAOA/VQE seeding and benchmarking metadata work from #47

## Validation

- `julia +release --project=. -e 'using Pkg; Pkg.test()'`
  - Passed.
  - QUBODrivers compatibility suite: `335/335`.

## Release notes draft

This minor release adds benchmark-facing QUBODrivers support for QAOA and VQE:

- Add standard `QUBODrivers.RandomSeed()` support for QAOA and VQE optimizers.
- Derive local Aer simulator and transpiler seeds deterministically from the standard sampler seed when explicit QiskitOpt seed attributes are unset.
- Emit QUBODrivers-compatible metadata for algorithm, backend name/version, execution mode, reads, optimizer counters, seeds, and effective time.
- Record structured backend metadata plus a scalar `metadata["backend_name"]` alias for scripts that only need the backend label.
- Add metadata conformance and compatibility coverage for local Aer runs.

Closes #43.
