### PR TITLE
Expose fixed-parameter QAOA circuit export

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,33 @@ initial vector under `metadata["initial_parameters"]`. Disable this with
 set_attribute(model, QiskitOpt.QAOA.RecordInitialParameters(), false)
 ```
 
+## Fixed-Parameter QAOA Circuits
+Use `QiskitOpt.QAOA.fixed_parameter_circuit` when parameters were trained
+outside QiskitOpt and you need the Qiskit circuit that QiskitOpt would bind for
+that QUBO. This path does not run `QAOA.Optimizer`, choose a backend, transpile,
+sample, or contact IBM Runtime.
+
+```julia
+qaoa_parameters = QiskitOpt.QAOA.fixed_angle_initial_parameters(number_of_layers=2)
+
+circuit, metadata = QiskitOpt.QAOA.fixed_parameter_circuit(
+    JuMP.unsafe_backend(model);
+    parameters=qaoa_parameters,
+    reps=2,
+    parameter_order=:beta_then_gamma,
+    measure=true,
+)
+```
+
+The metadata records QAOA depth, Qiskit parameter names and binding order,
+variable order, Qiskit count-key bit order, objective scale/offset, objective
+sign convention, and backend-independent circuit properties. Convert a Qiskit
+count key back to QUBO variable order with:
+
+```julia
+bits = QiskitOpt.QAOA.count_key_bits("0101")
+```
+
 ## Configuring Local Aer
 Both `QAOA.Optimizer` and `VQE.Optimizer` expose the same Aer local-simulation attributes. They apply when the optimizer builds the default local backend, and also when `IBMBackend()` is combined with `IsLocal() == true` to emulate a named IBM backend through Aer.
 

--- a/README.md
+++ b/README.md
@@ -176,8 +176,11 @@ circuit, metadata = QiskitOpt.QAOA.fixed_parameter_circuit(
 
 The metadata records QAOA depth, Qiskit parameter names and binding order,
 variable order, Qiskit count-key bit order, objective scale/offset, objective
-sign convention, and backend-independent circuit properties. Convert a Qiskit
-count key back to QUBO variable order with:
+sign convention, and backend-independent circuit properties. Parameter values
+stored in metadata always align with the Qiskit parameter names, regardless of
+the input order. Store caller-specific angle provenance, such as training seed
+or source path, alongside the returned metadata when you need it. Convert a
+Qiskit count key back to QUBO variable order with:
 
 ```julia
 bits = QiskitOpt.QAOA.count_key_bits("0101")

--- a/docs/qaoa_best_practices.md
+++ b/docs/qaoa_best_practices.md
@@ -158,7 +158,11 @@ circuit, metadata = QiskitOpt.QAOA.fixed_parameter_circuit(
 The metadata is intended to travel with exported circuits. It records variable
 order, Qiskit count-key order, QAOA parameter order, objective scale/offset,
 objective sign convention, and backend-independent circuit size information.
-Use `QiskitOpt.QAOA.count_key_bits(key)` to convert Qiskit count keys back to
+Parameter values stored in metadata always align with Qiskit parameter names,
+regardless of the caller's input order. Store caller-specific angle provenance,
+such as source path, training target, seed, or expected probabilities, alongside
+the returned metadata when you need it. Use
+`QiskitOpt.QAOA.count_key_bits(key)` to convert Qiskit count keys back to
 `[x1, x2, ...]` before scoring with `QUBOTools.value`.
 
 ## Moving From Aer To IBM Hardware

--- a/docs/qaoa_best_practices.md
+++ b/docs/qaoa_best_practices.md
@@ -137,6 +137,30 @@ the source, parameter names, and values when `RecordInitialParameters()` is
 true. Keep that enabled for experiments where angles are compared across
 simulators, seeds, or hardware backends.
 
+## Exporting Fixed-Parameter Circuits
+
+Use `QiskitOpt.QAOA.fixed_parameter_circuit` after parameter search is complete
+and the next step is submitting or inspecting a fixed QAOA circuit. It uses the
+same QUBO-to-Qiskit cost-operator path and Qiskit `QAOAAnsatz` parameter order
+as `QAOA.Optimizer`, but it does not run the optimizer loop, select a backend,
+invoke Runtime primitives, transpile, or sample.
+
+```julia
+circuit, metadata = QiskitOpt.QAOA.fixed_parameter_circuit(
+    JuMP.unsafe_backend(model);
+    parameters=trained_parameters,
+    reps=p,
+    parameter_order=:beta_then_gamma,
+    measure=true,
+)
+```
+
+The metadata is intended to travel with exported circuits. It records variable
+order, Qiskit count-key order, QAOA parameter order, objective scale/offset,
+objective sign convention, and backend-independent circuit size information.
+Use `QiskitOpt.QAOA.count_key_bits(key)` to convert Qiskit count keys back to
+`[x1, x2, ...]` before scoring with `QUBOTools.value`.
+
 ## Moving From Aer To IBM Hardware
 
 Use three stages when hardware execution is the goal:

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -335,6 +335,8 @@ function _fixed_parameter_metadata(
             "input_order" => String(parameter_order),
             "qiskit_order" => "beta_then_gamma",
             "parameter_names" => String.(parameter_names),
+            "values_order" => "qiskit_order",
+            "values_aligned_to" => "parameter_names",
             "values" => Float64.(parameter_values),
         ),
         "variables" => Dict{String,Any}(
@@ -397,7 +399,9 @@ QUBODrivers sampler and bind an explicit QAOA parameter vector without running
 then all gamma angles. Pass `parameter_order=:gamma_then_beta` to provide the
 opposite block order. The returned metadata records variable order, count-key
 bit order, parameter order, objective scale/offset, objective sign convention,
-and backend-independent circuit properties.
+and backend-independent circuit properties. Metadata parameter `values` are
+always stored in Qiskit binding order and align positionally with
+`parameter_names`; `input_order` records the caller's input format.
 """
 function fixed_parameter_circuit(
     source::MOI.ModelLike;

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -234,6 +234,209 @@ function parameter_count(problem_or_nqubits; number_of_layers::Integer)
     return length(parameter_names(problem_or_nqubits; number_of_layers=number_of_layers))
 end
 
+function _fixed_parameter_sampler(sampler::QUBODrivers.AbstractSampler)
+    return sampler
+end
+
+function _fixed_parameter_sampler(model::MOI.ModelLike)
+    sampler = QAOA.Optimizer{Float64}()
+    MOI.copy_to(sampler, model)
+    return sampler
+end
+
+function _stored_number_of_layers(model)
+    return MOI.get(model, QAOA.NumberOfLayers())
+end
+
+function _resolve_fixed_parameter_layers(source; reps, number_of_layers)
+    if isnothing(reps) && isnothing(number_of_layers)
+        return _check_number_of_layers(_stored_number_of_layers(source))
+    elseif isnothing(number_of_layers)
+        return _check_number_of_layers(reps)
+    elseif isnothing(reps)
+        return _check_number_of_layers(number_of_layers)
+    end
+
+    checked_reps = _check_number_of_layers(reps)
+    checked_layers = _check_number_of_layers(number_of_layers)
+    checked_reps == checked_layers ||
+        throw(ArgumentError("reps and number_of_layers must match when both are provided"))
+    return checked_layers
+end
+
+function _qiskit_ordered_qaoa_parameters(
+    parameters::AbstractVector,
+    number_of_layers::Integer,
+    parameter_order::Symbol,
+)
+    p = _check_number_of_layers(number_of_layers)
+    values = Float64.(parameters)
+    expected_count = 2 * p
+    if length(values) != expected_count
+        throw(
+            ArgumentError(
+                "fixed_parameter_circuit parameters length $(length(values)) does not match " *
+                "the expected QAOA parameter count $(expected_count)",
+            ),
+        )
+    end
+
+    if parameter_order in (:beta_then_gamma, :qiskit)
+        return values
+    elseif parameter_order == :gamma_then_beta
+        return vcat(values[(p + 1):end], values[1:p])
+    end
+
+    throw(ArgumentError("unsupported QAOA parameter_order: $(parameter_order)"))
+end
+
+function _objective_sense_name(sense)
+    sense == MOI.MIN_SENSE && return "min"
+    sense == MOI.MAX_SENSE && return "max"
+    return string(sense)
+end
+
+function _qiskit_minimization_sign(sense)
+    return sense == MOI.MIN_SENSE ? 1 : -1
+end
+
+function _circuit_operation_counts(circuit)
+    operations = Dict{String,Int}()
+    counts = circuit.count_ops()
+    for key in counts.keys()
+        operations[pyconvert(String, key)] = pyconvert(Int, counts[key])
+    end
+    return operations
+end
+
+function _fixed_parameter_metadata(
+    sampler::QUBODrivers.AbstractSampler,
+    circuit,
+    number_of_layers::Integer,
+    parameter_order::Symbol,
+    parameter_names::AbstractVector{<:AbstractString},
+    parameter_values::AbstractVector{<:Real},
+    measure::Bool,
+)
+    n, _, _, α, β = QUBOTools.qubo(sampler, :dense)
+    sense = MOI.get(sampler, MOI.ObjectiveSense())
+
+    return Dict{String,Any}(
+        "algorithm" => Dict{String,Any}(
+            "name" => "QAOA",
+            "mode" => "fixed_parameter_circuit",
+        ),
+        "qaoa" => Dict{String,Any}(
+            "number_of_layers" => number_of_layers,
+            "cost_layer" => "qiskit.circuit.library.QAOAAnsatz cost_operator",
+            "mixer" => "qiskit.circuit.library.QAOAAnsatz default mixer",
+        ),
+        "parameters" => Dict{String,Any}(
+            "input_order" => String(parameter_order),
+            "qiskit_order" => "beta_then_gamma",
+            "parameter_names" => String.(parameter_names),
+            "values" => Float64.(parameter_values),
+        ),
+        "variables" => Dict{String,Any}(
+            "count" => n,
+            "order" => string.(1:n),
+            "qubit_order" => "variable 1 maps to Qiskit qubit 0",
+        ),
+        "measurement" => Dict{String,Any}(
+            "enabled" => measure,
+            "classical_bit_order" => measure ? "variable 1 maps to classical bit 0" : nothing,
+            "qiskit_count_key_order" => "Qiskit count keys print classical bits from highest to lowest index",
+            "variable_bit_order" => "QAOA.count_key_bits(key) returns bits in variable order",
+        ),
+        "objective" => Dict{String,Any}(
+            "sense" => _objective_sense_name(sense),
+            "scale" => α,
+            "offset" => β,
+            "qiskit_minimization_sign" => _qiskit_minimization_sign(sense),
+            "value_convention" => "QUBOTools.value(bits, linear, quadratic, scale, offset)",
+        ),
+        "circuit" => Dict{String,Any}(
+            "num_qubits" => pyconvert(Int, circuit.num_qubits),
+            "num_clbits" => pyconvert(Int, circuit.num_clbits),
+            "depth" => pyconvert(Int, circuit.depth()),
+            "operations" => _circuit_operation_counts(circuit),
+        ),
+    )
+end
+
+"""
+    QAOA.count_key_bits(key)
+
+Convert a Qiskit count key into QUBO variable order.
+
+Qiskit count dictionaries print classical bits from the highest classical-bit
+index down to zero. QiskitOpt scores samples as `[x1, x2, ...]`, so this helper
+reverses the rendered key in the same way as `QAOA.Optimizer`.
+"""
+function count_key_bits(key)
+    return sample_bits(key)
+end
+
+"""
+    QAOA.count_key_bitstring(key)
+
+Convert a Qiskit count key into a bitstring in QUBO variable order.
+"""
+function count_key_bitstring(key)
+    return join(count_key_bits(key))
+end
+
+"""
+    QAOA.fixed_parameter_circuit(source; parameters, reps=nothing, number_of_layers=nothing, parameter_order=:beta_then_gamma, measure=true)
+
+Build a Qiskit `QAOAAnsatz` circuit from an MOI model-like source or
+QUBODrivers sampler and bind an explicit QAOA parameter vector without running
+`QAOA.Optimizer`.
+
+`parameters` defaults to Qiskit's QAOA list-binding order: all beta angles,
+then all gamma angles. Pass `parameter_order=:gamma_then_beta` to provide the
+opposite block order. The returned metadata records variable order, count-key
+bit order, parameter order, objective scale/offset, objective sign convention,
+and backend-independent circuit properties.
+"""
+function fixed_parameter_circuit(
+    source::MOI.ModelLike;
+    parameters,
+    reps = nothing,
+    number_of_layers = nothing,
+    parameter_order::Symbol = :beta_then_gamma,
+    measure::Bool = true,
+)
+    p = _resolve_fixed_parameter_layers(
+        source;
+        reps=reps,
+        number_of_layers=number_of_layers,
+    )
+    sampler = _fixed_parameter_sampler(source)
+    ising_hamiltonian = quadratic_program(sampler)[0]
+    ansatz = qiskit().circuit.library.QAOAAnsatz(
+        ising_hamiltonian,
+        reps=p,
+    )
+    parameter_names = qiskit_parameter_names(ansatz)
+    parameter_values = _qiskit_ordered_qaoa_parameters(parameters, p, parameter_order)
+    validate_initial_parameters(parameter_values, length(parameter_names), "QAOA")
+
+    circuit = ansatz.assign_parameters(numpy().array(parameter_values))
+    measure && circuit.measure_all()
+
+    metadata = _fixed_parameter_metadata(
+        sampler,
+        circuit,
+        p,
+        parameter_order,
+        parameter_names,
+        parameter_values,
+        measure,
+    )
+    return circuit, metadata
+end
+
 """
     QAOA.random_initial_parameters(; number_of_layers, seed=nothing, rng=nothing)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -594,6 +594,8 @@ end
     @test metadata["parameters"]["input_order"] == "beta_then_gamma"
     @test metadata["parameters"]["qiskit_order"] == "beta_then_gamma"
     @test metadata["parameters"]["parameter_names"] == ["β[0]", "γ[0]"]
+    @test metadata["parameters"]["values_order"] == "qiskit_order"
+    @test metadata["parameters"]["values_aligned_to"] == "parameter_names"
     @test metadata["parameters"]["values"] == parameters
     @test metadata["variables"]["order"] == ["1", "2"]
     @test metadata["measurement"]["enabled"]
@@ -604,6 +606,23 @@ end
     @test metadata["circuit"]["num_qubits"] == 2
     @test metadata["circuit"]["num_clbits"] == 2
     @test metadata["circuit"]["operations"]["measure"] == 2
+
+    max_model, _ = build_model(
+        QAOA.Optimizer;
+        Q=[
+            -1.0 2.0
+            2.0 -1.0
+        ],
+        sense=:Max,
+    )
+    _, max_metadata = QAOA.fixed_parameter_circuit(
+        max_model;
+        parameters=parameters,
+        reps=1,
+        measure=false,
+    )
+    @test max_metadata["objective"]["sense"] == "max"
+    @test max_metadata["objective"]["qiskit_minimization_sign"] == -1
 
     unmeasured = circuit.remove_final_measurements(inplace=false)
     exported_probabilities = QiskitOpt.PythonCall.pyconvert(
@@ -654,6 +673,8 @@ end
         QiskitOpt.qiskit().quantum_info.Statevector.from_instruction(reordered_circuit).probabilities_dict(),
     )
     @test reordered_metadata["parameters"]["input_order"] == "gamma_then_beta"
+    @test reordered_metadata["parameters"]["values_order"] == "qiskit_order"
+    @test reordered_metadata["parameters"]["values_aligned_to"] == "parameter_names"
     @test reordered_metadata["parameters"]["values"] == parameters
     @test Set(keys(reordered_probabilities)) == Set(keys(exported_probabilities))
     for key in keys(exported_probabilities)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -566,6 +566,128 @@ end
     @test vqe_seeded != VQE.random_initial_parameters(n_variables=3; seed=73002)
 end
 
+@testset "Fixed-parameter QAOA circuit export" begin
+    model, _ = build_model(
+        QAOA.Optimizer;
+        Q=[
+            -1.0 2.0
+            2.0 -1.0
+        ],
+        L=[0.5, -0.25],
+        scale=2.0,
+        offset=1.5,
+    )
+    qaoa_sampler = QAOA._fixed_parameter_sampler(model)
+    n, linear, quadratic, qubo_scale, qubo_offset = QUBOTools.qubo(qaoa_sampler, :dense)
+    @test n == 2
+
+    parameters = [0.23, -0.41]
+    circuit, metadata = QAOA.fixed_parameter_circuit(
+        model;
+        parameters=parameters,
+        reps=1,
+        measure=true,
+    )
+
+    @test metadata["algorithm"]["mode"] == "fixed_parameter_circuit"
+    @test metadata["qaoa"]["number_of_layers"] == 1
+    @test metadata["parameters"]["input_order"] == "beta_then_gamma"
+    @test metadata["parameters"]["qiskit_order"] == "beta_then_gamma"
+    @test metadata["parameters"]["parameter_names"] == ["β[0]", "γ[0]"]
+    @test metadata["parameters"]["values"] == parameters
+    @test metadata["variables"]["order"] == ["1", "2"]
+    @test metadata["measurement"]["enabled"]
+    @test metadata["objective"]["sense"] == "min"
+    @test metadata["objective"]["scale"] == qubo_scale
+    @test metadata["objective"]["offset"] == qubo_offset
+    @test metadata["objective"]["qiskit_minimization_sign"] == 1
+    @test metadata["circuit"]["num_qubits"] == 2
+    @test metadata["circuit"]["num_clbits"] == 2
+    @test metadata["circuit"]["operations"]["measure"] == 2
+
+    unmeasured = circuit.remove_final_measurements(inplace=false)
+    exported_probabilities = QiskitOpt.PythonCall.pyconvert(
+        Dict{String,Float64},
+        QiskitOpt.qiskit().quantum_info.Statevector.from_instruction(unmeasured).probabilities_dict(),
+    )
+
+    reference = QiskitOpt.qiskit().circuit.library.QAOAAnsatz(
+        QiskitOpt.quadratic_program(qaoa_sampler)[0],
+        reps=1,
+    ).assign_parameters(QiskitOpt.numpy().array(parameters))
+    reference_probabilities = QiskitOpt.PythonCall.pyconvert(
+        Dict{String,Float64},
+        QiskitOpt.qiskit().quantum_info.Statevector.from_instruction(reference).probabilities_dict(),
+    )
+
+    @test Set(keys(exported_probabilities)) == Set(keys(reference_probabilities))
+    for key in keys(reference_probabilities)
+        @test exported_probabilities[key] ≈ reference_probabilities[key]
+    end
+
+    uniform_circuit, uniform_metadata = QAOA.fixed_parameter_circuit(
+        model;
+        parameters=[0.0, 0.0],
+        reps=1,
+        measure=false,
+    )
+    uniform_probabilities = QiskitOpt.PythonCall.pyconvert(
+        Dict{String,Float64},
+        QiskitOpt.qiskit().quantum_info.Statevector.from_instruction(uniform_circuit).probabilities_dict(),
+    )
+    @test uniform_metadata["measurement"]["enabled"] == false
+    @test uniform_metadata["circuit"]["num_clbits"] == 0
+    @test Set(keys(uniform_probabilities)) == Set(["00", "01", "10", "11"])
+    for probability in values(uniform_probabilities)
+        @test probability ≈ 0.25
+    end
+
+    reordered_circuit, reordered_metadata = QAOA.fixed_parameter_circuit(
+        model;
+        parameters=[-0.41, 0.23],
+        reps=1,
+        parameter_order=:gamma_then_beta,
+        measure=false,
+    )
+    reordered_probabilities = QiskitOpt.PythonCall.pyconvert(
+        Dict{String,Float64},
+        QiskitOpt.qiskit().quantum_info.Statevector.from_instruction(reordered_circuit).probabilities_dict(),
+    )
+    @test reordered_metadata["parameters"]["input_order"] == "gamma_then_beta"
+    @test reordered_metadata["parameters"]["values"] == parameters
+    @test Set(keys(reordered_probabilities)) == Set(keys(exported_probabilities))
+    for key in keys(exported_probabilities)
+        @test reordered_probabilities[key] ≈ exported_probabilities[key]
+    end
+
+    @test QAOA.count_key_bits("10") == [0, 1]
+    @test QAOA.count_key_bitstring("10") == "01"
+    @test QUBOTools.value(QAOA.count_key_bits("10"), linear, quadratic, qubo_scale, qubo_offset) ≈
+          QUBOTools.value([0, 1], linear, quadratic, qubo_scale, qubo_offset)
+
+    MOI.set(model, QAOA.NumberOfLayers(), 1)
+    _, default_layer_metadata = QAOA.fixed_parameter_circuit(
+        model;
+        parameters=parameters,
+        measure=false,
+    )
+    @test default_layer_metadata["qaoa"]["number_of_layers"] == 1
+
+    @test_throws ArgumentError QAOA.fixed_parameter_circuit(model; parameters=[0.0], reps=1)
+    @test_throws ArgumentError QAOA.fixed_parameter_circuit(
+        model;
+        parameters=parameters,
+        reps=1,
+        number_of_layers=2,
+    )
+    @test_throws ArgumentError QAOA.fixed_parameter_circuit(
+        model;
+        parameters=parameters,
+        reps=1,
+        parameter_order=:interleaved,
+    )
+end
+
 @testset "Initial parameter validation fails before backend execution" begin
     previous_builder = QiskitOpt._runtime_service_builder[]
     QiskitOpt._runtime_service_builder[] = (; kwargs...) -> error("runtime service invoked")


### PR DESCRIPTION
Summary
- Adds `QiskitOpt.QAOA.fixed_parameter_circuit` for binding explicit QAOA parameters to the same Qiskit `QAOAAnsatz` cost-operator path used by `QAOA.Optimizer`, without running optimization, backend selection, Runtime primitives, transpilation, or sampling.
- Adds Qiskit count-key conversion helpers for returning bits in QUBO variable order.
- Records fixed-circuit metadata for QAOA depth, parameter order/names/values, variable and measurement bit order, objective scale/offset/sign convention, and backend-independent circuit properties.
- Documents fixed-parameter circuit export in the README and QAOA best-practices guide.

Tests
- `git diff --check` passed.
- `julia --project=. -e 'import Pkg; Pkg.test()'` passed.

Branch Hygiene
- Base branch: `main`
- Source branch: `fix/issue-46-fixed-qaoa-circuit`
- Source branch point: `origin/main` at `8ae356e`
- Stacked status: not stacked
- Prerequisite PRs: none

Closes #46
