### PR TITLE
Add IBM Runtime handoff for fixed QAOA circuits

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,41 @@ variable order, Qiskit count-key bit order, objective scale/offset, objective
 sign convention, and backend-independent circuit properties. Parameter values
 stored in metadata always align with the Qiskit parameter names, regardless of
 the input order. Store caller-specific angle provenance, such as training seed
-or source path, alongside the returned metadata when you need it. Convert a
+or source path, alongside the returned metadata when you need it.
+
+Use `QiskitOpt.QAOA.ibm_runtime_handoff` when the fixed circuit is ready for an
+IBM Runtime `SamplerV2` handoff. The default mode is a credential-free dry run:
+it records the intended backend, shots, transpiler seed, fixed-parameter
+metadata, package versions, and count-scoring convention without contacting IBM
+or writing token, instance/CRN, or account-file values into the metadata.
+
+```julia
+handoff = QiskitOpt.QAOA.ibm_runtime_handoff(
+    circuit;
+    fixed_metadata=metadata,
+    backend="ibm_fez",
+    shots=8192,
+    transpiler_seed=73001,
+)
+```
+
+Live submission is opt-in:
+
+```julia
+live_handoff = QiskitOpt.QAOA.ibm_runtime_handoff(
+    circuit;
+    fixed_metadata=metadata,
+    backend="ibm_fez",
+    shots=8192,
+    transpiler_seed=73001,
+    dry_run=false,
+)
+```
+
+Runtime credentials remain outside QiskitOpt artifacts and are read through the
+normal Qiskit Runtime account flow or environment variables. Set
+`QISKIT_IBM_INSTANCE` or pass `instance=...` when Runtime cannot auto-resolve an
+account instance; this may be required even when a token is present. Convert a
 Qiskit count key back to QUBO variable order with:
 
 ```julia

--- a/README.md
+++ b/README.md
@@ -213,8 +213,14 @@ live_handoff = QiskitOpt.QAOA.ibm_runtime_handoff(
 Runtime credentials remain outside QiskitOpt artifacts and are read through the
 normal Qiskit Runtime account flow or environment variables. Set
 `QISKIT_IBM_INSTANCE` or pass `instance=...` when Runtime cannot auto-resolve an
-account instance; this may be required even when a token is present. Convert a
-Qiskit count key back to QUBO variable order with:
+account instance; this may be required even when a token is present. If live
+setup, transpilation, or submission fails before a job is returned, catch
+`QiskitOpt.QAOA.RuntimeHandoffError` and persist `err.metadata`; `err.cause`
+retains the original exception. Failure-message redaction removes
+QiskitOpt-resolved token and instance values plus obvious `token=...`,
+`instance=...`, `account_file=...`, and `crn:...` fragments, but callers should
+still keep Runtime credentials outside project artifacts. Convert a Qiskit
+count key back to QUBO variable order with:
 
 ```julia
 bits = QiskitOpt.QAOA.count_key_bits("0101")

--- a/docs/qaoa_best_practices.md
+++ b/docs/qaoa_best_practices.md
@@ -165,6 +165,62 @@ the returned metadata when you need it. Use
 `QiskitOpt.QAOA.count_key_bits(key)` to convert Qiskit count keys back to
 `[x1, x2, ...]` before scoring with `QUBOTools.value`.
 
+## IBM Runtime Handoff For Fixed Circuits
+
+Use `QiskitOpt.QAOA.ibm_runtime_handoff` when QiskitOpt has built a measured,
+fixed-parameter QAOA circuit and another workflow is responsible for IBM
+Runtime account configuration and job monitoring. The helper is dry-runable by
+default, so it can be exercised in CI without credentials:
+
+```julia
+handoff = QiskitOpt.QAOA.ibm_runtime_handoff(
+    circuit;
+    fixed_metadata=metadata,
+    backend="ibm_fez",
+    shots=8192,
+    transpiler_seed=73001,
+)
+```
+
+The dry-run metadata records the intended backend, shot budget, transpiler
+seed, fixed QAOA parameter metadata, package versions, and count-key scoring
+assumptions. It records whether an instance selector is configured, but it does
+not record token values, instance/CRN values, account file paths, or other
+credential material.
+
+Live submission requires an explicit opt-in:
+
+```julia
+live_handoff = QiskitOpt.QAOA.ibm_runtime_handoff(
+    circuit;
+    fixed_metadata=metadata,
+    backend="ibm_fez",
+    shots=8192,
+    transpiler_seed=73001,
+    dry_run=false,
+)
+
+job = live_handoff.job
+job_id = live_handoff.metadata["runtime_handoff"]["job"]["id"]
+```
+
+The live path resolves the named backend with `QiskitRuntimeService`,
+transpiles the measured circuit with the requested seed and optimization level,
+then submits it through `qiskit_ibm_runtime.SamplerV2`. Credentials should come
+from normal Qiskit Runtime account storage or environment variables such as
+`QISKIT_IBM_TOKEN`; QiskitOpt does not persist them. Set
+`QISKIT_IBM_INSTANCE` or pass `instance=...` when Runtime cannot auto-resolve an
+account instance. In practice this may be required even when a token is present;
+the Runtime failure can look like:
+
+```text
+IBMInputValueError: No matching instances found for the following filters: .
+```
+
+Treat returned counts as Qiskit count keys. Convert keys with
+`QiskitOpt.QAOA.count_key_bits(key)`, then score them with the linear,
+quadratic, scale, and offset values from the original QUBO.
+
 ## Moving From Aer To IBM Hardware
 
 Use three stages when hardware execution is the goal:

--- a/docs/qaoa_best_practices.md
+++ b/docs/qaoa_best_practices.md
@@ -204,6 +204,30 @@ job = live_handoff.job
 job_id = live_handoff.metadata["runtime_handoff"]["job"]["id"]
 ```
 
+If live setup, transpilation, or submission fails before a job is returned,
+catch `QiskitOpt.QAOA.RuntimeHandoffError` and persist `err.metadata` before
+stopping or rethrowing:
+
+```julia
+try
+    live_handoff = QiskitOpt.QAOA.ibm_runtime_handoff(
+        circuit;
+        fixed_metadata=metadata,
+        backend="ibm_fez",
+        shots=8192,
+        transpiler_seed=73001,
+        dry_run=false,
+    )
+catch err
+    if err isa QiskitOpt.QAOA.RuntimeHandoffError
+        failure_metadata = err.metadata
+        original_error = err.cause
+        rethrow()
+    end
+    rethrow()
+end
+```
+
 The live path resolves the named backend with `QiskitRuntimeService`,
 transpiles the measured circuit with the requested seed and optimization level,
 then submits it through `qiskit_ibm_runtime.SamplerV2`. Credentials should come
@@ -216,6 +240,11 @@ the Runtime failure can look like:
 ```text
 IBMInputValueError: No matching instances found for the following filters: .
 ```
+
+Failure-message redaction removes QiskitOpt-resolved token and instance values
+plus obvious `token=...`, `instance=...`, `account_file=...`, and `crn:...`
+fragments from captured errors. Treat that as a final guardrail, not a reason to
+store credentials in project outputs.
 
 Treat returned counts as Qiskit count keys. Convert keys with
 `QiskitOpt.QAOA.count_key_bits(key)`, then score them with the linear,

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -530,9 +530,27 @@ function _redact_runtime_message(message::AbstractString, secrets)
         isempty(secret_text) && continue
         redacted = replace(redacted, secret_text => "[redacted]")
     end
+
+    redacted = replace(redacted, r"(?i)(token\s*[=:]\s*)[^\s,;]+" => s"\1[redacted]")
+    redacted = replace(redacted, r"(?i)(instance\s*[=:]\s*)[^\s,;]+" => s"\1[redacted]")
+    redacted = replace(redacted, r"(?i)(account[_ -]?file\s*[=:]\s*)[^\s,;]+" => s"\1[redacted]")
+    redacted = replace(redacted, r"(?i)\bcrn:[^\s,;]+" => "[redacted]")
     return redacted
 end
 
+"""
+    QAOA.RuntimeHandoffError
+
+Failure type thrown by `QAOA.ibm_runtime_handoff(...; dry_run=false)` when the
+live Runtime setup, transpilation, or submission path fails before a successful
+job is returned.
+
+Catch this exception when a workflow needs to persist the sanitized failure
+metadata. The `metadata` field contains the same handoff metadata shape returned
+by dry runs, with `metadata["runtime_handoff"]["status"] ==
+"failed_before_submission"` and a sanitized failure message. The `cause` field
+contains the original exception object.
+"""
 struct RuntimeHandoffError <: Exception
     metadata::Dict{String,Any}
     cause::Any
@@ -565,6 +583,15 @@ transpile the measured circuit, and submit it to `qiskit_ibm_runtime.SamplerV2`.
 Live submission reads credentials from normal Qiskit Runtime configuration and
 returns the submitted job object plus the same sanitized metadata with job
 status fields populated.
+
+If live setup, transpilation, or submission fails before a successful job is
+returned, this throws `QAOA.RuntimeHandoffError`. Catch it and read
+`err.metadata` to persist sanitized failure metadata before rethrowing or
+stopping the workflow. Failure-message redaction is best effort: it removes
+QiskitOpt-resolved token and instance values plus obvious `token=...`,
+`instance=...`, `account_file=...`, and `crn:...` fragments from the captured
+message, but callers should still keep Runtime credentials outside project
+artifacts and avoid logging raw upstream exceptions.
 """
 function ibm_runtime_handoff(
     circuit;

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -1,6 +1,6 @@
 module QAOA
 
-using PythonCall: pyconvert, pylist, pydict, pyint, @pyexec
+using PythonCall: pyconvert, pylist, pydict, pyint, pystr, @pyexec
 using ..QiskitOpt:
     AerBackendConfig,
     backend_name,
@@ -17,7 +17,9 @@ using ..QiskitOpt:
     quadratic_program,
     random_unit_values,
     runtime_channel,
+    runtime_service,
     runtime_instance,
+    runtime_token,
     sample_bits,
     scipy,
     numpy,
@@ -29,6 +31,15 @@ Sample = QUBODrivers.Sample
 SampleSet = QUBODrivers.SampleSet
 
 const FIXED_ANGLE_SOURCE = "Wurtz-Lykov 3-regular tree fixed-angle table; arXiv:2107.00677"
+const _HANDOFF_METADATA_SECTIONS = (
+    "algorithm",
+    "qaoa",
+    "parameters",
+    "variables",
+    "measurement",
+    "objective",
+    "circuit",
+)
 
 const _WURTZ_LYKOV_3REGULAR_TREE_ANGLES = Dict(
     1 => (gamma = [0.616], beta = [0.393], guarantee = 0.6925),
@@ -363,6 +374,271 @@ function _fixed_parameter_metadata(
             "depth" => pyconvert(Int, circuit.depth()),
             "operations" => _circuit_operation_counts(circuit),
         ),
+    )
+end
+
+function _check_runtime_backend(backend::AbstractString)
+    backend_name = strip(String(backend))
+    isempty(backend_name) && throw(ArgumentError("backend must be a non-empty IBM backend name"))
+    return backend_name
+end
+
+function _check_runtime_shots(shots::Integer)
+    shots >= 1 || throw(ArgumentError("shots must be at least 1"))
+    return Int(shots)
+end
+
+function _check_optimization_level(optimization_level::Integer)
+    0 <= optimization_level <= 3 ||
+        throw(ArgumentError("optimization_level must be between 0 and 3"))
+    return Int(optimization_level)
+end
+
+function _check_transpiler_seed(seed::Union{Integer,Nothing})
+    isnothing(seed) && return nothing
+    return Int(seed)
+end
+
+function _check_measured_circuit(circuit)
+    try
+        pyconvert(Int, circuit.num_clbits) >= 1 && return nothing
+    catch err
+        err isa ArgumentError && rethrow()
+        throw(ArgumentError("circuit must expose Qiskit num_clbits"))
+    end
+
+    throw(
+        ArgumentError(
+            "ibm_runtime_handoff expects a measured circuit; call " *
+            "QAOA.fixed_parameter_circuit(...; measure=true)",
+        ),
+    )
+end
+
+function _safe_fixed_parameter_metadata(fixed_metadata)
+    isnothing(fixed_metadata) && return Dict{String,Any}()
+
+    metadata = Dict{String,Any}()
+    for key in _HANDOFF_METADATA_SECTIONS
+        haskey(fixed_metadata, key) || continue
+        metadata[key] = deepcopy(fixed_metadata[key])
+    end
+    return metadata
+end
+
+function _julia_package_version()
+    try
+        version = Base.pkgversion(parentmodule(@__MODULE__))
+        return isnothing(version) ? nothing : string(version)
+    catch
+        return nothing
+    end
+end
+
+function _python_package_version(lazy_module)
+    try
+        loaded = lazy_module()
+        return pyconvert(String, loaded.__version__)
+    catch
+        return nothing
+    end
+end
+
+function _runtime_handoff_package_versions()
+    return Dict{String,Any}(
+        "QiskitOpt" => _julia_package_version(),
+        "qiskit" => _python_package_version(qiskit),
+        "qiskit_ibm_runtime" => _python_package_version(qiskit_ibm_runtime),
+    )
+end
+
+function _runtime_handoff_metadata(;
+    fixed_metadata,
+    backend::AbstractString,
+    shots::Integer,
+    transpiler_seed::Union{Integer,Nothing},
+    optimization_level::Integer,
+    dry_run::Bool,
+    channel::Union{Nothing,AbstractString},
+    instance::Union{Nothing,AbstractString},
+)
+    resolved_channel = runtime_channel(channel)
+    resolved_instance = runtime_instance(instance)
+
+    return Dict{String,Any}(
+        "runtime_handoff" => Dict{String,Any}(
+            "mode" => dry_run ? "dry_run" : "live",
+            "status" => dry_run ? "dry_run" : "preparing_submission",
+            "backend" => String(backend),
+            "shots" => Int(shots),
+            "optimization_level" => Int(optimization_level),
+            "transpiler_seed" => transpiler_seed,
+            "channel" => resolved_channel,
+            "instance_configured" => !isnothing(resolved_instance),
+            "credentials_recorded" => false,
+            "credential_fields_omitted" => ["token", "instance", "account_file", "crn"],
+            "instance_hint" =>
+                "QISKIT_IBM_INSTANCE or QAOA.Instance() may be required even when a token is present",
+        ),
+        "fixed_parameter_circuit" => _safe_fixed_parameter_metadata(fixed_metadata),
+        "count_scoring" => Dict{String,Any}(
+            "count_key_order" =>
+                "Qiskit count keys print classical bits from highest to lowest index",
+            "bit_conversion" => "QAOA.count_key_bits",
+            "value_convention" =>
+                "QUBOTools.value(bits, linear, quadratic, scale, offset)",
+        ),
+        "packages" => _runtime_handoff_package_versions(),
+    )
+end
+
+function _transpile_for_runtime(circuit, backend; optimization_level::Integer, transpiler_seed)
+    if isnothing(transpiler_seed)
+        return qiskit().transpile(
+            circuit;
+            backend=backend,
+            optimization_level=optimization_level,
+        )
+    end
+
+    return qiskit().transpile(
+        circuit;
+        backend=backend,
+        seed_transpiler=transpiler_seed,
+        optimization_level=optimization_level,
+    )
+end
+
+function _python_call_string(object, name::Symbol)
+    try
+        value = getproperty(object, name)
+        try
+            value = value()
+        catch
+        end
+        return pyconvert(String, pystr(value))
+    catch
+        return nothing
+    end
+end
+
+function _redact_runtime_message(message::AbstractString, secrets)
+    redacted = String(message)
+    for secret in secrets
+        isnothing(secret) && continue
+        secret_text = String(secret)
+        isempty(secret_text) && continue
+        redacted = replace(redacted, secret_text => "[redacted]")
+    end
+    return redacted
+end
+
+struct RuntimeHandoffError <: Exception
+    metadata::Dict{String,Any}
+    cause::Any
+end
+
+function Base.showerror(io::IO, err::RuntimeHandoffError)
+    print(io, "IBM Runtime handoff failed before a successful job submission")
+    failure = get(get(err.metadata, "runtime_handoff", Dict{String,Any}()), "failure", nothing)
+    if failure isa AbstractDict && haskey(failure, "message")
+        print(io, ": ", failure["message"])
+    else
+        print(io, ": ")
+        showerror(io, err.cause)
+    end
+end
+
+"""
+    QAOA.ibm_runtime_handoff(circuit; fixed_metadata=nothing, backend, shots, dry_run=true, transpiler_seed=nothing, optimization_level=3, channel=nothing, instance=nothing)
+
+Prepare a fixed-parameter QAOA circuit for IBM Runtime `SamplerV2`.
+
+The default `dry_run=true` path does not contact IBM Runtime. It returns
+sanitized metadata describing the intended backend, shots, transpiler seed,
+fixed-circuit parameter metadata, count-key scoring convention, package
+versions, and whether an instance selector was configured. Token values,
+instance/CRN values, and account file paths are never recorded.
+
+Set `dry_run=false` to resolve the backend through `QiskitRuntimeService`,
+transpile the measured circuit, and submit it to `qiskit_ibm_runtime.SamplerV2`.
+Live submission reads credentials from normal Qiskit Runtime configuration and
+returns the submitted job object plus the same sanitized metadata with job
+status fields populated.
+"""
+function ibm_runtime_handoff(
+    circuit;
+    fixed_metadata = nothing,
+    backend::AbstractString,
+    shots::Integer,
+    dry_run::Bool = true,
+    transpiler_seed::Union{Integer,Nothing} = nothing,
+    optimization_level::Integer = 3,
+    channel::Union{Nothing,AbstractString} = nothing,
+    instance::Union{Nothing,AbstractString} = nothing,
+)
+    _check_measured_circuit(circuit)
+    backend_label = _check_runtime_backend(backend)
+    shot_count = _check_runtime_shots(shots)
+    checked_seed = _check_transpiler_seed(transpiler_seed)
+    checked_optimization_level = _check_optimization_level(optimization_level)
+
+    metadata = _runtime_handoff_metadata(
+        fixed_metadata=fixed_metadata,
+        backend=backend_label,
+        shots=shot_count,
+        transpiler_seed=checked_seed,
+        optimization_level=checked_optimization_level,
+        dry_run=dry_run,
+        channel=channel,
+        instance=instance,
+    )
+
+    if dry_run
+        return (
+            metadata=metadata,
+            transpiled_circuit=nothing,
+            job=nothing,
+        )
+    end
+
+    service = runtime_backend = transpiled_circuit = job = nothing
+    try
+        service = runtime_service(channel=channel, instance=instance)
+        runtime_backend = service.backend(backend_label)
+        transpiled_circuit = _transpile_for_runtime(
+            circuit,
+            runtime_backend;
+            optimization_level=checked_optimization_level,
+            transpiler_seed=checked_seed,
+        )
+        sampler = qiskit_ibm_runtime().SamplerV2(mode=runtime_backend)
+        job = sampler.run(pylist([transpiled_circuit]), shots=pyint(shot_count))
+    catch err
+        handoff = metadata["runtime_handoff"]
+        handoff["status"] = "failed_before_submission"
+        handoff["failure"] = Dict{String,Any}(
+            "message" => _redact_runtime_message(
+                sprint(showerror, err),
+                (runtime_token(), runtime_instance(instance)),
+            ),
+            "instance_hint" =>
+                "QISKIT_IBM_INSTANCE or QAOA.Instance() may be required when Runtime cannot auto-resolve an account instance",
+        )
+        throw(RuntimeHandoffError(metadata, err))
+    end
+
+    handoff = metadata["runtime_handoff"]
+    handoff["status"] = "submitted"
+    handoff["job"] = Dict{String,Any}(
+        "id" => _python_call_string(job, :job_id),
+        "status" => _python_call_string(job, :status),
+    )
+
+    return (
+        metadata=metadata,
+        transpiled_circuit=transpiled_circuit,
+        job=job,
     )
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -607,6 +607,66 @@ end
     @test metadata["circuit"]["num_clbits"] == 2
     @test metadata["circuit"]["operations"]["measure"] == 2
 
+    previous_builder = QiskitOpt._runtime_service_builder[]
+    QiskitOpt._runtime_service_builder[] = (; kwargs...) -> error("runtime service invoked")
+    try
+        withenv(
+            "QISKIT_IBM_TOKEN" => "secret-token-issue-45",
+            "QISKIT_IBM_INSTANCE" => "secret-instance-issue-45",
+            "QISKIT_IBM_CHANNEL" => "ibm_quantum_platform",
+        ) do
+            unsafe_metadata = merge(
+                metadata,
+                Dict{String,Any}(
+                    "token" => "secret-token-issue-45",
+                    "instance" => "secret-instance-issue-45",
+                    "account_file" => "/tmp/secret-account.json",
+                ),
+            )
+
+            handoff = QAOA.ibm_runtime_handoff(
+                circuit;
+                fixed_metadata=unsafe_metadata,
+                backend="ibm_fez",
+                shots=4096,
+                transpiler_seed=73001,
+            )
+
+            @test handoff.job === nothing
+            @test handoff.transpiled_circuit === nothing
+            @test handoff.metadata["runtime_handoff"]["mode"] == "dry_run"
+            @test handoff.metadata["runtime_handoff"]["status"] == "dry_run"
+            @test handoff.metadata["runtime_handoff"]["backend"] == "ibm_fez"
+            @test handoff.metadata["runtime_handoff"]["shots"] == 4096
+            @test handoff.metadata["runtime_handoff"]["transpiler_seed"] == 73001
+            @test handoff.metadata["runtime_handoff"]["instance_configured"] == true
+            @test handoff.metadata["runtime_handoff"]["credentials_recorded"] == false
+            @test handoff.metadata["fixed_parameter_circuit"]["parameters"]["parameter_names"] == ["β[0]", "γ[0]"]
+            @test handoff.metadata["fixed_parameter_circuit"]["objective"]["value_convention"] ==
+                  "QUBOTools.value(bits, linear, quadratic, scale, offset)"
+            @test handoff.metadata["count_scoring"]["bit_conversion"] == "QAOA.count_key_bits"
+            @test haskey(handoff.metadata["packages"], "qiskit")
+            @test !haskey(handoff.metadata["fixed_parameter_circuit"], "token")
+            @test !haskey(handoff.metadata["fixed_parameter_circuit"], "instance")
+            @test !haskey(handoff.metadata["fixed_parameter_circuit"], "account_file")
+
+            handoff_text = repr(handoff.metadata)
+            @test !occursin("secret-token-issue-45", handoff_text)
+            @test !occursin("secret-instance-issue-45", handoff_text)
+            @test !occursin("/tmp/secret-account.json", handoff_text)
+        end
+    finally
+        QiskitOpt._runtime_service_builder[] = previous_builder
+    end
+
+    @test_throws ArgumentError QAOA.ibm_runtime_handoff(circuit; backend="", shots=1024)
+    @test_throws ArgumentError QAOA.ibm_runtime_handoff(circuit; backend="ibm_fez", shots=0)
+    @test_throws ArgumentError QAOA.ibm_runtime_handoff(
+        circuit.remove_final_measurements(inplace=false);
+        backend="ibm_fez",
+        shots=1024,
+    )
+
     max_model, _ = build_model(
         QAOA.Optimizer;
         Q=[

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -654,6 +654,45 @@ end
             @test !occursin("secret-token-issue-45", handoff_text)
             @test !occursin("secret-instance-issue-45", handoff_text)
             @test !occursin("/tmp/secret-account.json", handoff_text)
+
+            saved_account_token = "saved-account-token-issue-45"
+            secret_crn = "secret-crn-issue-45"
+            QiskitOpt._runtime_service_builder[] = (; kwargs...) -> error(
+                "auth failed token=$(saved_account_token) " *
+                "instance=secret-instance-issue-45 " *
+                "account_file=/tmp/secret-account.json " *
+                "crn:$(secret_crn)",
+            )
+
+            runtime_error = try
+                QAOA.ibm_runtime_handoff(
+                    circuit;
+                    fixed_metadata=unsafe_metadata,
+                    backend="ibm_fez",
+                    shots=4096,
+                    transpiler_seed=73001,
+                    dry_run=false,
+                )
+                nothing
+            catch err
+                err
+            end
+
+            @test runtime_error isa QAOA.RuntimeHandoffError
+            @test runtime_error.cause !== nothing
+            @test runtime_error.metadata["runtime_handoff"]["status"] == "failed_before_submission"
+            failure_message = runtime_error.metadata["runtime_handoff"]["failure"]["message"]
+            @test occursin("[redacted]", failure_message)
+            for secret in (
+                saved_account_token,
+                "secret-instance-issue-45",
+                "/tmp/secret-account.json",
+                secret_crn,
+            )
+                @test !occursin(secret, failure_message)
+                @test !occursin(secret, repr(runtime_error.metadata))
+                @test !occursin(secret, sprint(showerror, runtime_error))
+            end
         end
     finally
         QiskitOpt._runtime_service_builder[] = previous_builder


### PR DESCRIPTION
Summary
- Add `QiskitOpt.QAOA.ibm_runtime_handoff` for fixed-parameter QAOA circuits.
- Keep the default path credential-free and dry-runable while recording intended backend, shots, transpiler seed, package versions, fixed-circuit metadata, and count-key scoring assumptions.
- Add an opt-in live submission path through `QiskitRuntimeService`, Qiskit transpilation, and `qiskit_ibm_runtime.SamplerV2`.
- Document the handoff in the README and QAOA best-practices guide, including the practical need for `QISKIT_IBM_INSTANCE` or an explicit instance selector when Runtime cannot auto-resolve one.

Tests
- `git diff --check` - passed.
- `julia +release --project=. test/runtests.jl` - passed.
- `julia +release --project=. -e 'import Pkg; Pkg.test()'` - passed.

Branch Hygiene
- Base branch: `main`.
- Source branch point: `origin/main` at `7c7ddcd92540829f77ed1437f6a06b14783d3f71`.
- Source branch: `fix/issue-45-ibm-runtime-handoff`.
- Stacked status: not stacked; branch was created from current `origin/main`.
- Prerequisite PRs: none.

Closes #45
