### PR TITLE
Docs: update DS-MFG QAOA guidance

### DIFF
--- a/examples/ds_mfg_qubo/DSMFGQUBOExample.jl
+++ b/examples/ds_mfg_qubo/DSMFGQUBOExample.jl
@@ -352,14 +352,18 @@ function annotate_distributions(
 end
 
 function _configure_qaoa!(model, instance::QUBOInstance; number_of_reads::Integer, maximum_iterations::Integer)
+    # Keep optimizer and final shots equal for this cached tutorial.
     MOI.set(model, QAOA.NumberOfReads(), number_of_reads)
     MOI.set(model, QUBODrivers.FinalNumberOfReads(), number_of_reads)
     MOI.set(model, QAOA.MaximumIterations(), maximum_iterations)
+    # One layer keeps the compact tutorial cheap to rerun locally.
     MOI.set(model, QAOA.NumberOfLayers(), 1)
+    # Record fixed-angle provenance through InitialParameterSource().
     MOI.set(model, QAOA.InitialParameters(), QAOA.fixed_angle_initial_parameters(number_of_layers = 1))
     MOI.set(model, QAOA.InitialParameterSource(), QAOA.FIXED_ANGLE_SOURCE)
     MOI.set(model, QAOA.AerPrecision(), "single")
     MOI.set(model, QAOA.AerMaxParallelThreads(), 1)
+    # Pin local Aer and transpiler seeds for comparable regenerated samples.
     MOI.set(model, QAOA.AerSeedSimulator(), 73001)
     MOI.set(model, QAOA.TranspilerSeed(), 73001)
     return model

--- a/examples/ds_mfg_qubo/README.md
+++ b/examples/ds_mfg_qubo/README.md
@@ -38,6 +38,54 @@ Outputs are written under `examples/ds_mfg_qubo/output/`:
 - `distribution_comparison.svg`
 - `sample_distributions.csv` when rerun is enabled
 
+## QAOA Configuration
+
+This tutorial is intentionally local-first. The default command reads
+`data/cached_distributions.csv` so documentation builds, CI, and quick local
+checks can inspect the DS-MFG bookkeeping without spending time in a quantum
+optimizer. Regenerate the samples only when you want to inspect the local
+QAOA/VQE path directly. The cached rows are recorded outputs from this
+lightweight local configuration, not hardware benchmark data.
+
+The QAOA rerun settings follow the local validation workflow in the
+[QAOA best-practices guide](../../docs/qaoa_best_practices.md):
+
+- `QAOA.IBMBackend()` is left unset, so QiskitOpt.jl uses local Aer instead of
+  IBM Runtime hardware.
+- `QAOA.NumberOfLayers() = 1` keeps the five-variable tutorial cheap to rerun;
+  deeper or hardware-aware angle studies belong in a separate training
+  workflow.
+- `QAOA.NumberOfReads()` controls the optimizer sampling shot budget,
+  `QUBODrivers.FinalNumberOfReads()` controls final sampling shots, and
+  `QAOA.MaximumIterations()` controls the classical optimizer iteration budget.
+  This example sets both read counts to `128` and caps optimization at `10`
+  iterations.
+- `QAOA.InitialParameters()` uses
+  `QAOA.fixed_angle_initial_parameters(number_of_layers = 1)` and
+  `QAOA.InitialParameterSource()` records `QAOA.FIXED_ANGLE_SOURCE`, so the
+  starting angles remain auditable in metadata.
+- Local Aer uses the default `matrix_product_state` method with
+  `QAOA.AerPrecision() = "single"` and `QAOA.AerMaxParallelThreads() = 1`.
+- `QAOA.AerSeedSimulator() = 73001` and `QAOA.TranspilerSeed() = 73001` pin the
+  simulator and transpiler paths used when distributions are regenerated.
+
+For a different QAOA study, choose and record the initializer deliberately.
+Leave `InitialParameters()` unset for the documented zero default, use
+`QAOA.random_initial_parameters(...; seed = seed)` with a source such as
+`"random_seed_73001"`, keep the fixed-angle helper with
+`QAOA.FIXED_ANGLE_SOURCE`, or use a schedule helper such as
+`QAOA.linear_ramp_initial_parameters(...)` with a descriptive
+`InitialParameterSource()`.
+
+To move beyond this tutorial, first validate the QUBO, ordered angles, and
+local Aer results, then run hardware-aware mapping, transpilation, and angle
+training in an upstream workflow such as
+[`qopt-best-practices`](https://github.com/qiskit-community/qopt-best-practices).
+QiskitOpt.jl can export a fixed-parameter QAOA circuit and prepare a dry-run IBM
+Runtime handoff, but this example intentionally avoids embedding generic
+hardware transpilation, qubit selection, SWAP strategies, or angle-training
+infrastructure.
+
 ## Rerun Local Aer
 
 The cached path is intended for normal documentation and CI use. To regenerate
@@ -56,6 +104,8 @@ parameters, and deterministic simulator/transpiler seeds where supported:
 - `MaximumIterations() = 10`
 - `AerPrecision() = "single"`
 - `AerMaxParallelThreads() = 1`
+- `AerSeedSimulator() = 73001`
+- `TranspilerSeed() = 73001`
 
 You can redirect generated files with `QISKITOPT_DSMFG_OUTPUT_DIR`.
 

--- a/examples/ds_mfg_qubo/README.md
+++ b/examples/ds_mfg_qubo/README.md
@@ -47,27 +47,23 @@ optimizer. Regenerate the samples only when you want to inspect the local
 QAOA/VQE path directly. The cached rows are recorded outputs from this
 lightweight local configuration, not hardware benchmark data.
 
-The QAOA rerun settings follow the local validation workflow in the
+The QAOA rerun settings listed in [Rerun Local Aer](#rerun-local-aer) follow
+the local validation workflow in the
 [QAOA best-practices guide](../../docs/qaoa_best_practices.md):
 
 - `QAOA.IBMBackend()` is left unset, so QiskitOpt.jl uses local Aer instead of
   IBM Runtime hardware.
-- `QAOA.NumberOfLayers() = 1` keeps the five-variable tutorial cheap to rerun;
-  deeper or hardware-aware angle studies belong in a separate training
-  workflow.
+- A small `QAOA.NumberOfLayers()` value keeps the five-variable tutorial cheap
+  to rerun; deeper or hardware-aware angle studies belong in a separate
+  training workflow.
 - `QAOA.NumberOfReads()` controls the optimizer sampling shot budget,
   `QUBODrivers.FinalNumberOfReads()` controls final sampling shots, and
-  `QAOA.MaximumIterations()` controls the classical optimizer iteration budget.
-  This example sets both read counts to `128` and caps optimization at `10`
-  iterations.
-- `QAOA.InitialParameters()` uses
-  `QAOA.fixed_angle_initial_parameters(number_of_layers = 1)` and
-  `QAOA.InitialParameterSource()` records `QAOA.FIXED_ANGLE_SOURCE`, so the
-  starting angles remain auditable in metadata.
-- Local Aer uses the default `matrix_product_state` method with
-  `QAOA.AerPrecision() = "single"` and `QAOA.AerMaxParallelThreads() = 1`.
-- `QAOA.AerSeedSimulator() = 73001` and `QAOA.TranspilerSeed() = 73001` pin the
-  simulator and transpiler paths used when distributions are regenerated.
+  `QAOA.MaximumIterations()` controls the classical optimizer iteration
+  budget.
+- `QAOA.InitialParameters()` and `QAOA.InitialParameterSource()` record
+  fixed-angle provenance, so the starting angles remain auditable in metadata.
+- Local Aer precision, thread, simulator-seed, and transpiler-seed attributes
+  are pinned for comparable regenerated samples.
 
 For a different QAOA study, choose and record the initializer deliberately.
 Leave `InitialParameters()` unset for the documented zero default, use
@@ -96,16 +92,22 @@ QISKITOPT_DSMFG_RERUN=true julia --project=. examples/ds_mfg_qubo/ds_mfg_qubo_qi
 ```
 
 The rerun path uses local Aer defaults, fixed QAOA angles, seeded VQE initial
-parameters, and deterministic simulator/transpiler seeds where supported:
+parameters, and deterministic simulator/transpiler seeds where supported. The
+QAOA attributes are:
 
+- `QAOA.IBMBackend()` unset
 - `QAOA.NumberOfLayers() = 1`
-- `NumberOfReads() = 128`
+- `QAOA.NumberOfReads() = 128`
 - `QUBODrivers.FinalNumberOfReads() = 128`
-- `MaximumIterations() = 10`
-- `AerPrecision() = "single"`
-- `AerMaxParallelThreads() = 1`
-- `AerSeedSimulator() = 73001`
-- `TranspilerSeed() = 73001`
+- `QAOA.MaximumIterations() = 10`
+- `QAOA.InitialParameters() =
+  QAOA.fixed_angle_initial_parameters(number_of_layers = 1)`
+- `QAOA.InitialParameterSource() = QAOA.FIXED_ANGLE_SOURCE`
+- `QAOA.AerBackendMethod()` default: `"matrix_product_state"`
+- `QAOA.AerPrecision() = "single"`
+- `QAOA.AerMaxParallelThreads() = 1`
+- `QAOA.AerSeedSimulator() = 73001`
+- `QAOA.TranspilerSeed() = 73001`
 
 You can redirect generated files with `QISKITOPT_DSMFG_OUTPUT_DIR`.
 


### PR DESCRIPTION
## Summary

- Add DS-MFG QAOA configuration guidance covering cached local Aer validation, depth, reads, fixed-angle provenance, seeds, and Aer attributes.
- Explain how to choose and record alternate fixed-angle, random, or schedule initializers with `InitialParameterSource()`.
- Clarify the hardware handoff boundary: validate locally, use upstream hardware-aware workflows for mapping/training, and avoid embedding generic transpilation or angle-training infrastructure in the example.
- Add short comments beside the example's QAOA configuration choices.

## Tests

- `QISKITOPT_DSMFG_OUTPUT_DIR=/tmp/qiskitopt-issue36-output julia --project=. examples/ds_mfg_qubo/ds_mfg_qubo_qiskitopt.jl` - passed; cached distributions path generated summary and SVG under `/tmp/qiskitopt-issue36-output`.
- `julia --project=. -e 'using Pkg; Pkg.test()'` - passed.

## Branch Hygiene

- Base branch: `main`
- Head branch: `fix/issue-36-ds-mfg-qaoa-guidance`
- Source branch point: `origin/main` at `2db10676ba5c9f3795d12be4e5ddfad8a0d08eb8`
- Stacked status: not stacked; the branch was created from current `origin/main`.
- Prerequisite PRs: none.

Closes #36
