### PR TITLE
Close QAOA upstream triage tracker

### DIFF
--- a/docs/qaoa_best_practices.md
+++ b/docs/qaoa_best_practices.md
@@ -320,10 +320,11 @@ custom factory. VQE does not expose this QAOA-specific hook.
 
 QiskitOpt.jl should remain the JuMP/MOI adapter that sends a QUBO to Qiskit,
 selects the execution backend, records seeds and angle metadata, and returns
-samples. Broader QAOA research workflows belong upstream. Track any proposed
-upstream follow-up from
-[QiskitOpt.jl#38](https://github.com/JuliaQUBO/QiskitOpt.jl/issues/38) before
-opening an issue or pull request in another repository:
+samples. Broader QAOA research workflows belong upstream. The upstream triage
+for this guide is recorded in
+[QiskitOpt.jl#38](https://github.com/JuliaQUBO/QiskitOpt.jl/issues/38). Open a
+new QiskitOpt.jl issue before filing any future upstream follow-up so the
+candidate, rationale, and owning repository are explicit:
 
 | Upstream home | Follow-up candidate | Current triage |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

- Reword the QAOA upstream-boundary guide so #38 is a completed triage record rather than the ongoing tracking home.
- Direct future upstream follow-ups to start with a fresh QiskitOpt.jl issue that records the candidate, rationale, and owning repository.

Closes #38

## Tests

- `git diff --check` passed.

## Branch Hygiene

- Base branch: `main`
- Source branch: `fix/issue-38-close-tracker`
- Source branch point: `cfb8568c2b2d990303eb02d76becd406031228ef` (`origin/main`)
- Stacked status: not stacked
- Prerequisite PRs: none
