### PR TITLE
ci: harden TagBot permissions

### DIFF
--- a/.github/workflows/tagbot.yml
+++ b/.github/workflows/tagbot.yml
@@ -4,6 +4,10 @@ on:
     types:
       - created
   workflow_dispatch:
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
Summary

- Harden TagBot workflow permissions so tag/release writes and manual-intervention issue creation do not depend on repository default token settings.
- Preserve the existing TagBot SSH configuration where present.

Validation

- git diff --check

Notes

- This PR does not change package code or release metadata.
