### PR TITLE
Add dry-run QAOA resource audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,35 @@ stored in metadata always align with the Qiskit parameter names, regardless of
 the input order. Store caller-specific angle provenance, such as training seed
 or source path, alongside the returned metadata when you need it.
 
+Use `QiskitOpt.QAOA.resource_audit` before a noisy simulator or hardware run to
+record circuit resources without submitting a job or reading IBM credentials.
+When `backend` is omitted, the audit transpiles against QiskitOpt's
+credential-free local Aer backend. Pass a Qiskit fake backend, local
+`AerSimulator.from_backend(...)`, or IBM backend object when you need a specific
+target.
+
+```julia
+audit = QiskitOpt.QAOA.resource_audit(
+    JuMP.unsafe_backend(model);
+    parameters=qaoa_parameters,
+    reps=2,
+    optimization_level=3,
+    transpiler_seed=73001,
+    measure=true,
+)
+
+audit.metadata["untranspiled_circuit"]
+audit.metadata["transpilation"]["status"] # "success", "skipped", or "failed"
+audit.metadata["transpiled_circuit"]
+```
+
+The returned metadata includes QAOA layer and parameter details, variable and
+measurement order, untranspiled depth/size/operation counts, backend target
+summary, transpiler seed and optimization level, transpiled depth/size/operation
+counts, two-qubit operation counts, measured-bit count, layout summary when
+available, sanitized failure metadata, and QiskitOpt/Qiskit package versions.
+Set `transpile=false` to record only the untranspiled circuit.
+
 Use `QiskitOpt.QAOA.ibm_runtime_handoff` when the fixed circuit is ready for an
 IBM Runtime `SamplerV2` handoff. The default mode is a credential-free dry run:
 it records the intended backend, shots, transpiler seed, fixed-parameter

--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ measurement order, untranspiled depth/size/operation counts, backend target
 summary, transpiler seed and optimization level, transpiled depth/size/operation
 counts, two-qubit operation counts, measured-bit count, layout summary when
 available, sanitized failure metadata, and QiskitOpt/Qiskit package versions.
-Set `transpile=false` to record only the untranspiled circuit.
+Set `transpile=false` to record only the untranspiled circuit. The default Aer
+backend is useful for credential-free transpilation checks; pass a fake or real
+backend target when layout and routing metadata are part of the audit decision.
 
 Use `QiskitOpt.QAOA.ibm_runtime_handoff` when the fixed circuit is ready for an
 IBM Runtime `SamplerV2` handoff. The default mode is a credential-free dry run:

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -1,6 +1,6 @@
 module QAOA
 
-using PythonCall: pyconvert, pylist, pydict, pyint, pylen, pystr, @pyexec
+using PythonCall: PyException, pyconvert, pylist, pydict, pyint, pylen, pystr, @pyexec
 using ..QiskitOpt:
     AerBackendConfig,
     backend_name,
@@ -717,9 +717,14 @@ function _resource_audit_package_versions()
     )
 end
 
+function _resource_audit_exception_type(err)
+    err isa PyException && return _python_qualified_type(err.v)
+    return string(nameof(typeof(err)))
+end
+
 function _resource_audit_failure_metadata(err)
     return Dict{String,Any}(
-        "exception_type" => string(nameof(typeof(err))),
+        "exception_type" => _resource_audit_exception_type(err),
         "message" => _redact_runtime_message(
             sprint(showerror, err),
             (runtime_token(), runtime_instance()),
@@ -791,11 +796,10 @@ function _record_resource_audit_pass_manager!(metadata, pass_manager_selection)
     return metadata
 end
 
-function _mark_resource_audit_success!(metadata, transpiled_circuit, pass_manager_selection)
+function _mark_resource_audit_success!(metadata, transpiled_circuit)
     metadata["status"] = "success"
     transpilation = metadata["transpilation"]
     transpilation["status"] = "success"
-    _record_resource_audit_pass_manager!(metadata, pass_manager_selection)
     metadata["transpiled_circuit"] = _circuit_resource_metadata(transpiled_circuit)
     metadata["transpiled_circuit"]["layout"] = _transpiled_layout_metadata(transpiled_circuit)
     return metadata
@@ -891,7 +895,6 @@ function resource_audit(
         _mark_resource_audit_success!(
             metadata,
             transpiled_circuit,
-            pass_manager_selection,
         )
     catch err
         _mark_resource_audit_failed!(metadata, err)

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -1,6 +1,6 @@
 module QAOA
 
-using PythonCall: pyconvert, pylist, pydict, pyint, pystr, @pyexec
+using PythonCall: pyconvert, pylist, pydict, pyint, pylen, pystr, @pyexec
 using ..QiskitOpt:
     AerBackendConfig,
     backend_name,
@@ -320,6 +320,178 @@ function _circuit_operation_counts(circuit)
     return operations
 end
 
+function _python_qualified_type(object)
+    try
+        class_object = getproperty(object, :__class__)
+        module_name = pyconvert(String, getproperty(class_object, :__module__))
+        class_name = pyconvert(String, getproperty(class_object, :__name__))
+        return "$(module_name).$(class_name)"
+    catch
+        return string(typeof(object))
+    end
+end
+
+function _python_len_or_nothing(object)
+    try
+        return Int(pylen(object))
+    catch
+        return nothing
+    end
+end
+
+function _python_string_vector(object)
+    values = String[]
+    try
+        for item in object
+            push!(values, pyconvert(String, pystr(item)))
+        end
+    catch
+        return String[]
+    end
+    return sort!(unique(values))
+end
+
+function _python_object_summary(object; limit::Integer = 600)
+    try
+        text = pyconvert(String, pystr(object))
+        length(text) <= limit && return text
+        return text[begin:nextind(text, 0, limit)] * "..."
+    catch
+        return nothing
+    end
+end
+
+function _circuit_int_call(circuit, name::Symbol)
+    try
+        return pyconvert(Int, getproperty(circuit, name)())
+    catch
+        return nothing
+    end
+end
+
+function _instruction_operation_name(instruction)
+    try
+        return pyconvert(String, pystr(getproperty(getproperty(instruction, :operation), :name)))
+    catch
+        return nothing
+    end
+end
+
+function _instruction_width(instruction, field::Symbol)
+    try
+        return _python_len_or_nothing(getproperty(instruction, field))
+    catch
+        return nothing
+    end
+end
+
+function _two_qubit_operation_counts(circuit)
+    counts = Dict{String,Int}()
+    try
+        for instruction in circuit.data
+            _instruction_width(instruction, :qubits) == 2 || continue
+            name = _instruction_operation_name(instruction)
+            isnothing(name) && continue
+            name in ("barrier", "delay") && continue
+            counts[name] = get(counts, name, 0) + 1
+        end
+    catch
+        return Dict{String,Int}()
+    end
+    return counts
+end
+
+function _measured_bit_count(circuit)
+    measured = 0
+    try
+        for instruction in circuit.data
+            _instruction_operation_name(instruction) == "measure" || continue
+            width = _instruction_width(instruction, :clbits)
+            isnothing(width) || (measured += width)
+        end
+    catch
+        return nothing
+    end
+    return measured
+end
+
+function _circuit_resource_metadata(circuit)
+    two_qubit_counts = _two_qubit_operation_counts(circuit)
+    return Dict{String,Any}(
+        "num_qubits" => pyconvert(Int, circuit.num_qubits),
+        "num_clbits" => pyconvert(Int, circuit.num_clbits),
+        "depth" => _circuit_int_call(circuit, :depth),
+        "size" => _circuit_int_call(circuit, :size),
+        "operations" => _circuit_operation_counts(circuit),
+        "two_qubit_operation_counts" => two_qubit_counts,
+        "two_qubit_operation_count" => sum(values(two_qubit_counts); init=0),
+        "measured_bit_count" => _measured_bit_count(circuit),
+    )
+end
+
+function _target_resource_metadata(target)
+    metadata = Dict{String,Any}(
+        "type" => _python_qualified_type(target),
+        "num_qubits" => python_int_property(target, :num_qubits),
+    )
+
+    try
+        operation_names = _python_string_vector(getproperty(target, :operation_names))
+        isempty(operation_names) || (metadata["operation_names"] = operation_names)
+    catch
+    end
+
+    try
+        coupling_map = target.build_coupling_map()
+        edges = coupling_map.get_edges()
+        edge_count = _python_len_or_nothing(edges)
+        isnothing(edge_count) || (metadata["coupling_edge_count"] = edge_count)
+    catch
+    end
+
+    return metadata
+end
+
+function _backend_resource_metadata(backend, source::AbstractString)
+    metadata = Dict{String,Any}(
+        "source" => String(source),
+        "type" => _python_qualified_type(backend),
+        "name" => backend_name(backend),
+        "version" => backend_version(backend),
+        "num_qubits" => python_int_property(backend, :num_qubits),
+    )
+
+    try
+        metadata["basis_gates"] = _python_string_vector(backend.configuration().basis_gates)
+    catch
+    end
+
+    try
+        metadata["target"] = _target_resource_metadata(getproperty(backend, :target))
+    catch
+    end
+
+    return metadata
+end
+
+function _transpiled_layout_metadata(circuit)
+    try
+        layout = getproperty(circuit, :layout)
+        summary = Dict{String,Any}(
+            "available" => true,
+            "type" => _python_qualified_type(layout),
+            "summary" => _python_object_summary(layout),
+        )
+        for field in (:initial_layout, :final_layout, :input_qubit_mapping)
+            value = _python_object_summary(getproperty(layout, field))
+            isnothing(value) || (summary[string(field)] = value)
+        end
+        return summary
+    catch
+        return Dict{String,Any}("available" => false)
+    end
+end
+
 function _fixed_parameter_metadata(
     sampler::QUBODrivers.AbstractSampler,
     circuit,
@@ -536,6 +708,199 @@ function _redact_runtime_message(message::AbstractString, secrets)
     redacted = replace(redacted, r"(?i)(account[_ -]?file\s*[=:]\s*)[^\s,;]+" => s"\1[redacted]")
     redacted = replace(redacted, r"(?i)\bcrn:[^\s,;]+" => "[redacted]")
     return redacted
+end
+
+function _resource_audit_package_versions()
+    return Dict{String,Any}(
+        "QiskitOpt" => _julia_package_version(),
+        "qiskit" => _python_package_version(qiskit),
+    )
+end
+
+function _resource_audit_failure_metadata(err)
+    return Dict{String,Any}(
+        "exception_type" => string(nameof(typeof(err))),
+        "message" => _redact_runtime_message(
+            sprint(showerror, err),
+            (runtime_token(), runtime_instance()),
+        ),
+    )
+end
+
+function _copy_resource_audit_sections!(metadata, fixed_metadata)
+    safe_metadata = _safe_fixed_parameter_metadata(fixed_metadata)
+    for section in ("qaoa", "parameters", "variables", "measurement", "objective")
+        haskey(safe_metadata, section) || continue
+        metadata[section] = safe_metadata[section]
+    end
+    isempty(safe_metadata) || (metadata["fixed_parameter_circuit"] = safe_metadata)
+    return metadata
+end
+
+function _resource_audit_backend(backend, transpile::Bool)
+    transpile || return (backend=nothing, source="not_requested")
+    isnothing(backend) && return (backend=default_local_backend(), source="default_local_backend")
+    return (backend=backend, source="user_backend")
+end
+
+function _resource_audit_base_metadata(
+    circuit;
+    fixed_metadata,
+    backend,
+    backend_source::AbstractString,
+    optimization_level::Integer,
+    transpiler_seed,
+)
+    metadata = Dict{String,Any}(
+        "algorithm" => Dict{String,Any}(
+            "name" => "QAOA",
+            "mode" => "resource_audit",
+        ),
+        "untranspiled_circuit" => _circuit_resource_metadata(circuit),
+        "transpilation" => Dict{String,Any}(
+            "optimization_level" => optimization_level,
+            "transpiler_seed" => transpiler_seed,
+        ),
+        "packages" => _resource_audit_package_versions(),
+    )
+
+    if isnothing(backend)
+        metadata["backend"] = Dict{String,Any}("source" => String(backend_source))
+    else
+        metadata["backend"] = _backend_resource_metadata(backend, backend_source)
+    end
+
+    _copy_resource_audit_sections!(metadata, fixed_metadata)
+    return metadata
+end
+
+function _mark_resource_audit_skipped!(metadata, reason::AbstractString)
+    metadata["status"] = "skipped_transpilation"
+    transpilation = metadata["transpilation"]
+    transpilation["status"] = "skipped"
+    transpilation["reason"] = String(reason)
+    return metadata
+end
+
+function _record_resource_audit_pass_manager!(metadata, pass_manager_selection)
+    transpilation = metadata["transpilation"]
+    transpilation["pass_manager"] = Dict{String,Any}(
+        "source" => pass_manager_selection.source,
+        "optimization_level" => pass_manager_selection.optimization_level,
+    )
+    return metadata
+end
+
+function _mark_resource_audit_success!(metadata, transpiled_circuit, pass_manager_selection)
+    metadata["status"] = "success"
+    transpilation = metadata["transpilation"]
+    transpilation["status"] = "success"
+    _record_resource_audit_pass_manager!(metadata, pass_manager_selection)
+    metadata["transpiled_circuit"] = _circuit_resource_metadata(transpiled_circuit)
+    metadata["transpiled_circuit"]["layout"] = _transpiled_layout_metadata(transpiled_circuit)
+    return metadata
+end
+
+function _mark_resource_audit_failed!(metadata, err)
+    metadata["status"] = "failed_transpilation"
+    transpilation = metadata["transpilation"]
+    transpilation["status"] = "failed"
+    transpilation["failure"] = _resource_audit_failure_metadata(err)
+    return metadata
+end
+
+"""
+    QAOA.resource_audit(source; parameters, reps=nothing, number_of_layers=nothing, parameter_order=:beta_then_gamma, measure=true, backend=nothing, transpile=true, optimization_level=3, transpiler_seed=73001, pass_manager_factory=nothing, return_transpiled_circuit=false)
+
+Build a fixed-parameter QAOA circuit and return dry-run resource metadata
+without submitting a job or touching IBM account state.
+
+When `transpile=true` and `backend` is not provided, the audit uses the
+credential-free local Aer backend. Pass a Qiskit backend object, such as a fake
+backend or an `AerSimulator.from_backend(...)` instance, to audit against a
+specific target. Set `transpile=false` to record only the untranspiled circuit
+metadata.
+"""
+function resource_audit(
+    source::MOI.ModelLike;
+    parameters,
+    reps = nothing,
+    number_of_layers = nothing,
+    parameter_order::Symbol = :beta_then_gamma,
+    measure::Bool = true,
+    kwargs...
+)
+    circuit, fixed_metadata = fixed_parameter_circuit(
+        source;
+        parameters=parameters,
+        reps=reps,
+        number_of_layers=number_of_layers,
+        parameter_order=parameter_order,
+        measure=measure,
+    )
+    return resource_audit(circuit; fixed_metadata=fixed_metadata, kwargs...)
+end
+
+"""
+    QAOA.resource_audit(circuit; fixed_metadata=nothing, backend=nothing, transpile=true, optimization_level=3, transpiler_seed=73001, pass_manager_factory=nothing, return_transpiled_circuit=false)
+
+Return dry-run resource metadata for an existing Qiskit circuit.
+
+The result is a named tuple with `metadata` and `transpiled_circuit`. Failure to
+transpile is reported as sanitized structured metadata with
+`metadata["transpilation"]["status"] == "failed"`; no job is submitted.
+"""
+function resource_audit(
+    circuit;
+    fixed_metadata = nothing,
+    backend = nothing,
+    transpile::Bool = true,
+    optimization_level::Integer = 3,
+    transpiler_seed::Union{Integer,Nothing} = 73001,
+    pass_manager_factory = nothing,
+    return_transpiled_circuit::Bool = false,
+)
+    checked_optimization_level = _check_optimization_level(optimization_level)
+    checked_seed = _check_transpiler_seed(transpiler_seed)
+    backend_selection = _resource_audit_backend(backend, transpile)
+
+    metadata = _resource_audit_base_metadata(
+        circuit;
+        fixed_metadata=fixed_metadata,
+        backend=backend_selection.backend,
+        backend_source=backend_selection.source,
+        optimization_level=checked_optimization_level,
+        transpiler_seed=checked_seed,
+    )
+
+    if !transpile
+        _mark_resource_audit_skipped!(metadata, "transpile=false")
+        return (metadata=metadata, transpiled_circuit=nothing)
+    end
+
+    transpiled_circuit = nothing
+    try
+        pass_manager_selection = _selected_pass_manager(
+            backend_selection.backend;
+            factory=pass_manager_factory,
+            optimization_level=checked_optimization_level,
+            seed_transpiler=checked_seed,
+        )
+        _record_resource_audit_pass_manager!(metadata, pass_manager_selection)
+        transpiled_circuit = pass_manager_selection.pass_manager.run(circuit)
+        _mark_resource_audit_success!(
+            metadata,
+            transpiled_circuit,
+            pass_manager_selection,
+        )
+    catch err
+        _mark_resource_audit_failed!(metadata, err)
+    end
+
+    return (
+        metadata=metadata,
+        transpiled_circuit=return_transpiled_circuit ? transpiled_circuit : nothing,
+    )
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -781,6 +781,25 @@ end
         end
     end
 
+    python_failing_pass_manager_factory = (backend; optimization_level=3, seed_transpiler=nothing) -> (
+        run = inner_circuit -> QiskitOpt.qiskit().transpile(
+            inner_circuit;
+            backend="not-a-backend",
+        ),
+    )
+    python_failed_audit = QAOA.resource_audit(
+        circuit;
+        fixed_metadata=metadata,
+        backend=QiskitOpt.default_local_backend(),
+        pass_manager_factory=python_failing_pass_manager_factory,
+    )
+    @test python_failed_audit.transpiled_circuit === nothing
+    @test python_failed_audit.metadata["status"] == "failed_transpilation"
+    python_failure = python_failed_audit.metadata["transpilation"]["failure"]
+    @test python_failure["exception_type"] == "builtins.AttributeError"
+    @test occursin("AttributeError", python_failure["message"])
+    @test !occursin("PyException", python_failure["exception_type"])
+
     @test_throws ArgumentError QAOA.resource_audit(circuit; optimization_level=4)
 
     @test_throws ArgumentError QAOA.ibm_runtime_handoff(circuit; backend="", shots=1024)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -698,6 +698,91 @@ end
         QiskitOpt._runtime_service_builder[] = previous_builder
     end
 
+    resource_audit = QAOA.resource_audit(
+        model;
+        parameters=parameters,
+        reps=1,
+        optimization_level=1,
+        transpiler_seed=73001,
+        return_transpiled_circuit=true,
+    )
+    @test resource_audit.transpiled_circuit !== nothing
+    @test resource_audit.metadata["algorithm"]["mode"] == "resource_audit"
+    @test resource_audit.metadata["status"] == "success"
+    @test resource_audit.metadata["qaoa"]["number_of_layers"] == 1
+    @test resource_audit.metadata["parameters"]["parameter_names"] == ["β[0]", "γ[0]"]
+    @test resource_audit.metadata["parameters"]["values"] == parameters
+    @test resource_audit.metadata["variables"]["count"] == 2
+    @test resource_audit.metadata["measurement"]["enabled"]
+    @test resource_audit.metadata["backend"]["source"] == "default_local_backend"
+    @test startswith(resource_audit.metadata["backend"]["name"], "aer_simulator")
+    @test haskey(resource_audit.metadata["backend"], "target")
+    @test resource_audit.metadata["transpilation"]["status"] == "success"
+    @test resource_audit.metadata["transpilation"]["optimization_level"] == 1
+    @test resource_audit.metadata["transpilation"]["transpiler_seed"] == 73001
+    @test resource_audit.metadata["transpilation"]["pass_manager"]["source"] == "default_preset"
+    @test resource_audit.metadata["untranspiled_circuit"]["num_qubits"] == 2
+    @test resource_audit.metadata["untranspiled_circuit"]["num_clbits"] == 2
+    @test resource_audit.metadata["untranspiled_circuit"]["operations"]["measure"] == 2
+    @test resource_audit.metadata["untranspiled_circuit"]["size"] >=
+          resource_audit.metadata["untranspiled_circuit"]["depth"]
+    @test resource_audit.metadata["transpiled_circuit"]["num_qubits"] >= 2
+    @test resource_audit.metadata["transpiled_circuit"]["measured_bit_count"] == 2
+    @test resource_audit.metadata["transpiled_circuit"]["two_qubit_operation_count"] isa Integer
+    @test resource_audit.metadata["transpiled_circuit"]["layout"]["available"] isa Bool
+    @test haskey(resource_audit.metadata["packages"], "QiskitOpt")
+    @test haskey(resource_audit.metadata["packages"], "qiskit")
+
+    skipped_audit = QAOA.resource_audit(circuit; fixed_metadata=metadata, transpile=false)
+    @test skipped_audit.transpiled_circuit === nothing
+    @test skipped_audit.metadata["status"] == "skipped_transpilation"
+    @test skipped_audit.metadata["backend"]["source"] == "not_requested"
+    @test skipped_audit.metadata["transpilation"]["status"] == "skipped"
+    @test skipped_audit.metadata["transpilation"]["reason"] == "transpile=false"
+    @test !haskey(skipped_audit.metadata, "transpiled_circuit")
+
+    resource_secret_token = "resource-audit-secret-token"
+    resource_secret_instance = "resource-audit-secret-instance"
+    resource_secret_account_file = "/tmp/resource-audit-account.json"
+    resource_secret_crn = "resource-audit-crn"
+    failing_pass_manager_factory = (backend; optimization_level=3, seed_transpiler=nothing) -> (
+        run = _ -> error(
+            "transpile failed token=$(resource_secret_token) " *
+            "instance=$(resource_secret_instance) " *
+            "account_file=$(resource_secret_account_file) " *
+            "crn:$(resource_secret_crn)",
+        ),
+    )
+    withenv(
+        "QISKIT_IBM_TOKEN" => resource_secret_token,
+        "QISKIT_IBM_INSTANCE" => resource_secret_instance,
+    ) do
+        failed_audit = QAOA.resource_audit(
+            circuit;
+            fixed_metadata=metadata,
+            backend=QiskitOpt.default_local_backend(),
+            pass_manager_factory=failing_pass_manager_factory,
+        )
+        @test failed_audit.transpiled_circuit === nothing
+        @test failed_audit.metadata["status"] == "failed_transpilation"
+        @test failed_audit.metadata["transpilation"]["status"] == "failed"
+        @test failed_audit.metadata["transpilation"]["pass_manager"]["source"] == "custom_factory"
+        failure = failed_audit.metadata["transpilation"]["failure"]
+        @test failure["exception_type"] == "ErrorException"
+        @test occursin("[redacted]", failure["message"])
+        for secret in (
+            resource_secret_token,
+            resource_secret_instance,
+            resource_secret_account_file,
+            resource_secret_crn,
+        )
+            @test !occursin(secret, failure["message"])
+            @test !occursin(secret, repr(failed_audit.metadata))
+        end
+    end
+
+    @test_throws ArgumentError QAOA.resource_audit(circuit; optimization_level=4)
+
     @test_throws ArgumentError QAOA.ibm_runtime_handoff(circuit; backend="", shots=1024)
     @test_throws ArgumentError QAOA.ibm_runtime_handoff(circuit; backend="ibm_fez", shots=0)
     @test_throws ArgumentError QAOA.ibm_runtime_handoff(


### PR DESCRIPTION
Summary
- Add `QAOA.resource_audit` for fixed-parameter QAOA circuits and existing Qiskit circuits.
- Record untranspiled/transpiled circuit size, depth, operation counts, two-qubit counts, measured-bit count, backend target details, layout summary, transpiler options, package versions, and sanitized failure metadata.
- Document the audit workflow before IBM Runtime handoff.

Tests
- `julia +release --project=. -e 'using Pkg; Pkg.test()'` - passed.
- `julia --project=. -e 'using Pkg; Pkg.test()'` - did not reach tests in this checkout because the local ignored `Manifest.toml` was resolved with Julia 1.12 and Julia 1.10 Pkg refused to instantiate `OpenSSL_jll`.
- `git diff --check` - passed.

Branch Hygiene
- Base branch: `main`
- Source branch point: `origin/main` at `a213750`
- Stacked status: not stacked
- Prerequisite PRs: none

Closes #56
