### PR TITLE
Record optimized variational parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,33 @@ initial vector under `metadata["initial_parameters"]`. Disable this with
 set_attribute(model, QiskitOpt.QAOA.RecordInitialParameters(), false)
 ```
 
+After a QAOA or VQE solve, `metadata["optimized_parameters"]` records the final
+optimizer vector in the same order as `metadata["optimized_parameters"]["parameter_names"]`.
+For QAOA this is the Qiskit order used by `QAOAAnsatz` and
+`fixed_parameter_circuit`: beta angles followed by gamma angles. For VQE it is
+the selected Qiskit ansatz parameter order.
+
+```julia
+MOI = QiskitOpt.QUBODrivers.MOI
+raw_solver = MOI.get(JuMP.unsafe_backend(model), MOI.RawSolver())
+sampleset = QiskitOpt.QUBOTools.solution(raw_solver)
+metadata = QiskitOpt.QUBOTools.metadata(sampleset)
+
+trained = metadata["optimized_parameters"]
+trained["parameter_names"]
+trained["values"]
+trained["optimizer"]["objective_value"]
+
+qaoa_reps = div(length(trained["values"]), 2)
+qaoa_circuit, qaoa_metadata = QiskitOpt.QAOA.fixed_parameter_circuit(
+    JuMP.unsafe_backend(model);
+    parameters=trained["values"],
+    reps=qaoa_reps,
+    parameter_order=:qiskit,
+    measure=true,
+)
+```
+
 ## Fixed-Parameter QAOA Circuits
 Use `QiskitOpt.QAOA.fixed_parameter_circuit` when parameters were trained
 outside QiskitOpt and you need the Qiskit circuit that QiskitOpt would bind for

--- a/README.md
+++ b/README.md
@@ -160,7 +160,10 @@ After a QAOA or VQE solve, `metadata["optimized_parameters"]` records the final
 optimizer vector in the same order as `metadata["optimized_parameters"]["parameter_names"]`.
 For QAOA this is the Qiskit order used by `QAOAAnsatz` and
 `fixed_parameter_circuit`: beta angles followed by gamma angles. For VQE it is
-the selected Qiskit ansatz parameter order.
+the selected Qiskit ansatz parameter order. Use the top-level
+`metadata["optimizer"]` for run-level optimizer accounting, and
+`metadata["optimized_parameters"]["optimizer"]` for optimizer result fields tied
+to the recorded trained vector.
 
 ```julia
 MOI = QiskitOpt.QUBODrivers.MOI

--- a/src/QAOA.jl
+++ b/src/QAOA.jl
@@ -23,6 +23,8 @@ using ..QiskitOpt:
     sample_bits,
     scipy,
     numpy,
+    optimizer_result_metadata,
+    python_float_vector,
     validate_initial_parameters
 
 using QUBO
@@ -1346,6 +1348,14 @@ function retrieve(
         method="cobyla",
         options=scipy_options,
     )
+    optimizer_iterations = python_int_property(result, :nit)
+    optimizer_evaluations = python_int_property(result, :nfev)
+    optimized_parameter_values = python_float_vector(result.x)
+    optimized_parameter_optimizer = optimizer_result_metadata(
+        result;
+        iterations=optimizer_iterations,
+        function_evaluations=optimizer_evaluations,
+    )
 
     qc = ansatz.assign_parameters(result.x)
     qc.measure_all()
@@ -1366,8 +1376,8 @@ function retrieve(
         backend_config_source=backend_selection.source,
         number_of_reads=final_num_reads,
         final_number_of_reads=final_num_reads,
-        optimizer_iterations=python_int_property(result, :nit),
-        optimizer_evaluations=python_int_property(result, :nfev),
+        optimizer_iterations=optimizer_iterations,
+        optimizer_evaluations=optimizer_evaluations,
         optimizer_number_of_reads=num_reads,
         seed_sampler=sampler_seed,
         seed_transpiler=aer_config.seed_transpiler,
@@ -1377,6 +1387,9 @@ function retrieve(
         initial_parameters=record_initial_parameters ? initial_parameter_values : nothing,
         initial_parameter_names=record_initial_parameters ? parameter_names : nothing,
         initial_parameter_source=record_initial_parameters ? initial_parameter_source : nothing,
+        optimized_parameters=optimized_parameter_values,
+        optimized_parameter_names=parameter_names,
+        optimized_parameter_optimizer=optimized_parameter_optimizer,
     )
 end
 

--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -695,6 +695,38 @@ function python_int_property(object, name::Symbol)
     end
 end
 
+function python_float_property(object, name::Symbol)
+    try
+        return PythonCall.pyconvert(Float64, getproperty(object, name))
+    catch
+        return nothing
+    end
+end
+
+function python_bool_property(object, name::Symbol)
+    try
+        return PythonCall.pyconvert(Bool, getproperty(object, name))
+    catch
+        return nothing
+    end
+end
+
+function python_string_property(object, name::Symbol)
+    try
+        return PythonCall.pyconvert(String, PythonCall.pystr(getproperty(object, name)))
+    catch
+        return nothing
+    end
+end
+
+function python_float_vector(object)
+    try
+        return PythonCall.pyconvert(Vector{Float64}, object)
+    catch
+        return Float64[PythonCall.pyconvert(Float64, value) for value in object]
+    end
+end
+
 function qiskit_parameter_names(circuit)
     return String[
         PythonCall.pyconvert(String, PythonCall.pystr(parameter))
@@ -732,6 +764,34 @@ function initial_parameter_metadata(
     )
 end
 
+function optimizer_result_metadata(
+    result;
+    iterations = python_int_property(result, :nit),
+    function_evaluations = python_int_property(result, :nfev),
+)
+    return Dict{String,Any}(
+        "success" => python_bool_property(result, :success),
+        "status" => python_int_property(result, :status),
+        "message" => python_string_property(result, :message),
+        "objective_value" => python_float_property(result, :fun),
+        "iterations" => iterations,
+        "function_evaluations" => function_evaluations,
+    )
+end
+
+function optimized_parameter_metadata(
+    values::AbstractVector,
+    names::AbstractVector{<:AbstractString},
+    optimizer::Union{AbstractDict,Nothing},
+)
+    return Dict{String,Any}(
+        "source" => "optimizer_result",
+        "parameter_names" => String.(names),
+        "values" => Float64.(values),
+        "optimizer" => isnothing(optimizer) ? Dict{String,Any}() : Dict{String,Any}(optimizer),
+    )
+end
+
 function empty_metadata(
     algorithm::AbstractString,
     backend::AbstractString,
@@ -752,6 +812,9 @@ function empty_metadata(
     initial_parameters::Union{AbstractVector,Nothing} = nothing,
     initial_parameter_names::Union{AbstractVector{<:AbstractString},Nothing} = nothing,
     initial_parameter_source::Union{AbstractString,Nothing} = nothing,
+    optimized_parameters::Union{AbstractVector,Nothing} = nothing,
+    optimized_parameter_names::Union{AbstractVector{<:AbstractString},Nothing} = nothing,
+    optimized_parameter_optimizer::Union{AbstractDict,Nothing} = nothing,
 )
     metadata = Dict{String,Any}(
         "origin" => "$(algorithm) @ $(backend)",
@@ -808,6 +871,15 @@ function empty_metadata(
         source = isnothing(initial_parameter_source) ? "unknown" : initial_parameter_source
         names = isnothing(initial_parameter_names) ? String[] : initial_parameter_names
         metadata["initial_parameters"] = initial_parameter_metadata(source, initial_parameters, names)
+    end
+
+    if !isnothing(optimized_parameters)
+        names = isnothing(optimized_parameter_names) ? String[] : optimized_parameter_names
+        metadata["optimized_parameters"] = optimized_parameter_metadata(
+            optimized_parameters,
+            names,
+            optimized_parameter_optimizer,
+        )
     end
 
     return metadata

--- a/src/VQE.jl
+++ b/src/VQE.jl
@@ -21,6 +21,8 @@ using ..QiskitOpt:
     sample_bits,
     scipy,
     numpy,
+    optimizer_result_metadata,
+    python_float_vector,
     validate_initial_parameters
 
 using QUBO
@@ -247,6 +249,14 @@ function retrieve(
         method="cobyla",
         options=scipy_options,
     )
+    optimizer_iterations = python_int_property(result, :nit)
+    optimizer_evaluations = python_int_property(result, :nfev)
+    optimized_parameter_values = python_float_vector(result.x)
+    optimized_parameter_optimizer = optimizer_result_metadata(
+        result;
+        iterations=optimizer_iterations,
+        function_evaluations=optimizer_evaluations,
+    )
 
     qc = ansatz.assign_parameters(result.x)
     qc.measure_all()
@@ -267,8 +277,8 @@ function retrieve(
         backend_config_source=backend_selection.source,
         number_of_reads=final_num_reads,
         final_number_of_reads=final_num_reads,
-        optimizer_iterations=python_int_property(result, :nit),
-        optimizer_evaluations=python_int_property(result, :nfev),
+        optimizer_iterations=optimizer_iterations,
+        optimizer_evaluations=optimizer_evaluations,
         optimizer_number_of_reads=num_reads,
         seed_sampler=sampler_seed,
         seed_transpiler=aer_config.seed_transpiler,
@@ -276,6 +286,9 @@ function retrieve(
         initial_parameters=record_initial_parameters ? initial_parameter_values : nothing,
         initial_parameter_names=record_initial_parameters ? parameter_names : nothing,
         initial_parameter_source=record_initial_parameters ? initial_parameter_source : nothing,
+        optimized_parameters=optimized_parameter_values,
+        optimized_parameter_names=parameter_names,
+        optimized_parameter_optimizer=optimized_parameter_optimizer,
     )
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -988,6 +988,18 @@ end
         @test metadata["initial_parameters"]["source"] == initial_parameter_source
         @test metadata["initial_parameters"]["parameter_names"] == initial_parameter_names
         @test metadata["initial_parameters"]["values"] == initial_parameters
+        optimized_parameters = metadata["optimized_parameters"]
+        @test optimized_parameters["source"] == "optimizer_result"
+        @test optimized_parameters["parameter_names"] == initial_parameter_names
+        @test optimized_parameters["values"] isa Vector{Float64}
+        @test length(optimized_parameters["parameter_names"]) == length(optimized_parameters["values"])
+        optimizer_result = optimized_parameters["optimizer"]
+        @test optimizer_result["success"] isa Union{Bool,Nothing}
+        @test optimizer_result["status"] isa Union{Integer,Nothing}
+        @test optimizer_result["message"] isa Union{String,Nothing}
+        @test optimizer_result["objective_value"] isa Union{Float64,Nothing}
+        @test optimizer_result["iterations"] == metadata["optimizer"]["iterations"]
+        @test optimizer_result["function_evaluations"] == metadata["optimizer"]["evaluations"]
         if optimizer_module === QAOA
             @test metadata["pass_manager"]["source"] == "default_preset"
             @test metadata["pass_manager"]["optimization_level"] == 3


### PR DESCRIPTION
Summary
- Record final optimizer vectors under `metadata["optimized_parameters"]` for QAOA and VQE.
- Include ordered parameter names, Float64 values, and stable SciPy optimizer result fields.
- Document extracting the optimized vector and reusing it with `QAOA.fixed_parameter_circuit`.

Tests
- `git diff --check` passed.
- `julia +1.12 --project=. -e 'import Pkg; Pkg.test()'` passed.
- `julia --project=. -e 'import Pkg; Pkg.test()'` could not run locally because the default Julia 1.10 environment rejected the existing manifest as generated for Julia 1.12 and could not locate `OpenSSL_jll`.

Branch Hygiene
- Base branch: `main`.
- Source branch: `fix/issue-57-optimized-parameters`.
- Source branch point: `aadd8a7978b6ec92d05ae69f30c909d2e5695c23` (`origin/main` at branch creation).
- Stacked status: not stacked; this branch is one commit ahead of `origin/main`.
- Prerequisite PRs: none.

Closes #57
