### PR TITLE
Add sample postprocessing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,11 @@ first_row["derived"]["original_objective"]
 
 The helper returns a new `SampleSet`; raw states, reads, probabilities, and QUBO
 objective values are copied unchanged, while derived fields are stored under
-`metadata["postprocessing"]["rows"][i]["derived"]`. To skip postprocessing, do
-not call the helper, or pass `enabled=false` when keeping one code path for
-processed and unprocessed runs. Callback failures throw
+`metadata["postprocessing"]["rows"][i]["derived"]`. The callback context includes
+a shared read-only snapshot of the original `SampleSet` metadata as
+`context.metadata`. To skip postprocessing, do not call the helper, or pass
+`enabled=false` when keeping one code path for processed and unprocessed runs.
+Callback failures throw
 `QiskitOpt.SamplePostprocessingError` instead of returning a partially annotated
 result.
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,45 @@ qaoa_circuit, qaoa_metadata = QiskitOpt.QAOA.fixed_parameter_circuit(
 )
 ```
 
+## Sample Postprocessing
+Raw QUBO samples are kept as the solver returned them. When an application needs
+projected variables, feasibility flags, repaired objectives, or labels from the
+original model, attach those derived values with `postprocess_samples`:
+
+```julia
+processed = QiskitOpt.postprocess_samples(
+    sampleset;
+    name="toy_projection",
+    version="1.0.0",
+    source_problem="two-bit original model",
+    scoring_convention="sum projected decision bits",
+) do sample, context
+    bits = QiskitOpt.QUBOTools.state(sample)
+    projected = bits[1:2]
+
+    return Dict(
+        "original_objective" => sum(projected),
+        "feasible" => sum(projected) <= 1,
+        "projected_variables" => projected,
+    )
+end
+
+postprocessing = QiskitOpt.QUBOTools.metadata(processed)["postprocessing"]
+first_row = postprocessing["rows"][1]
+first_row["raw_value"]                  # unchanged QUBO objective
+first_row["reads"]                      # raw sample count
+first_row["probability"]                # reads / total reads
+first_row["derived"]["original_objective"]
+```
+
+The helper returns a new `SampleSet`; raw states, reads, probabilities, and QUBO
+objective values are copied unchanged, while derived fields are stored under
+`metadata["postprocessing"]["rows"][i]["derived"]`. To skip postprocessing, do
+not call the helper, or pass `enabled=false` when keeping one code path for
+processed and unprocessed runs. Callback failures throw
+`QiskitOpt.SamplePostprocessingError` instead of returning a partially annotated
+result.
+
 ## Fixed-Parameter QAOA Circuits
 Use `QiskitOpt.QAOA.fixed_parameter_circuit` when parameters were trained
 outside QiskitOpt and you need the Qiskit circuit that QiskitOpt would bind for

--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -894,7 +894,7 @@ function _postprocessing_context(
     sample,
     rank::Integer,
     total_reads::Integer,
-    source_metadata::Dict{String,Any},
+    metadata_snapshot::Dict{String,Any},
 )
     reads = QUBOTools.reads(sample)
     probability = iszero(total_reads) ? 0.0 : reads / total_reads
@@ -906,7 +906,7 @@ function _postprocessing_context(
         reads = reads,
         probability = probability,
         total_reads = total_reads,
-        metadata = deepcopy(source_metadata),
+        metadata = metadata_snapshot,
     )
 end
 
@@ -933,9 +933,11 @@ derived fields attached under `metadata["postprocessing"]`.
 
 The callback receives a copied sample and a context named tuple with `rank`,
 `state`, `raw_value`, `reads`, `probability`, `total_reads`, and the original
-metadata. It must return an `AbstractDict` or `NamedTuple`; keys are stringified
-for serialization-friendly metadata. Callback failures are rethrown as
-`SamplePostprocessingError` so raw quantum results are not silently corrupted.
+metadata. `context.metadata` is a shared read-only snapshot; do not mutate it
+from the callback. The callback must return an `AbstractDict` or `NamedTuple`;
+keys are stringified for serialization-friendly metadata. Callback failures are
+rethrown as `SamplePostprocessingError` so raw quantum results are not silently
+corrupted.
 """
 function postprocess_samples(
     postprocessor::Function,

--- a/src/QiskitOpt.jl
+++ b/src/QiskitOpt.jl
@@ -26,6 +26,23 @@ function Base.showerror(io::IO, err::PythonPackageError)
     end
 end
 
+struct SamplePostprocessingError <: Exception
+    rank::Int
+    sample::Any
+    cause::Any
+end
+
+function Base.showerror(io::IO, err::SamplePostprocessingError)
+    print(io, "sample postprocessing failed at rank $(err.rank)")
+    try
+        print(io, " for state ", QUBOTools.state(err.sample))
+        print(io, " with raw value ", QUBOTools.value(err.sample))
+    catch
+    end
+    print(io, "\nOriginal error: ")
+    showerror(io, err.cause)
+end
+
 Base.@kwdef struct RuntimeDiagnostic
     name::String
     ok::Bool
@@ -792,6 +809,189 @@ function optimized_parameter_metadata(
     )
 end
 
+function _serializable_postprocessing_value(value, path::AbstractString)
+    if value === nothing || value isa Bool || value isa AbstractString || value isa Integer
+        return value
+    elseif value isa AbstractFloat
+        isfinite(value) || throw(ArgumentError("postprocessing value at $(path) must be finite"))
+        return value
+    elseif value isa Symbol || value isa VersionNumber
+        return string(value)
+    elseif value isa AbstractDict || value isa NamedTuple
+        return _string_key_dict(value, path)
+    elseif value isa AbstractArray || value isa Tuple
+        return Any[
+            _serializable_postprocessing_value(item, "$(path)[$(index)]") for
+            (index, item) in enumerate(value)
+        ]
+    end
+
+    throw(
+        ArgumentError(
+            "postprocessing value at $(path) must be serializable; got $(typeof(value))",
+        ),
+    )
+end
+
+function _string_key_dict(data::AbstractDict, path::AbstractString = "metadata")
+    return Dict{String,Any}(
+        string(key) => _serializable_postprocessing_value(value, "$(path).$(string(key))") for
+        (key, value) in data
+    )
+end
+
+function _string_key_dict(data::NamedTuple, path::AbstractString = "metadata")
+    return Dict{String,Any}(
+        string(key) => _serializable_postprocessing_value(value, "$(path).$(string(key))") for
+        (key, value) in pairs(data)
+    )
+end
+
+function _derived_sample_fields(result)
+    if result isa AbstractDict || result isa NamedTuple
+        return _string_key_dict(result, "derived")
+    end
+
+    throw(
+        ArgumentError(
+            "sample postprocessor must return an AbstractDict or NamedTuple; got $(typeof(result))",
+        ),
+    )
+end
+
+function _postprocessing_metadata(metadata)
+    isnothing(metadata) && return Dict{String,Any}()
+    if metadata isa AbstractDict || metadata isa NamedTuple
+        return _string_key_dict(metadata)
+    end
+
+    throw(
+        ArgumentError(
+            "postprocessing metadata must be an AbstractDict, NamedTuple, or nothing; " *
+            "got $(typeof(metadata))",
+        ),
+    )
+end
+
+function _copied_sampleset(sampleset::QUBOTools.SampleSet{T,U}) where {T,U}
+    samples = QUBOTools.Sample{T,U}[
+        QUBOTools.Sample{T,U}(
+            copy(QUBOTools.state(sample)),
+            QUBOTools.value(sample),
+            QUBOTools.reads(sample),
+        ) for sample in sampleset
+    ]
+
+    return QUBOTools.SampleSet{T,U}(
+        samples;
+        metadata = deepcopy(QUBOTools.metadata(sampleset)),
+        sense    = QUBOTools.sense(sampleset),
+        domain   = QUBOTools.domain(sampleset),
+    )
+end
+
+function _postprocessing_context(
+    sample,
+    rank::Integer,
+    total_reads::Integer,
+    source_metadata::Dict{String,Any},
+)
+    reads = QUBOTools.reads(sample)
+    probability = iszero(total_reads) ? 0.0 : reads / total_reads
+
+    return (
+        rank = Int(rank),
+        state = copy(QUBOTools.state(sample)),
+        raw_value = QUBOTools.value(sample),
+        reads = reads,
+        probability = probability,
+        total_reads = total_reads,
+        metadata = deepcopy(source_metadata),
+    )
+end
+
+function _postprocessing_row(context)
+    state = copy(context.state)
+
+    return Dict{String,Any}(
+        "rank" => context.rank,
+        "state" => state,
+        "bitstring" => join(string.(state)),
+        "raw_value" => context.raw_value,
+        "reads" => context.reads,
+        "probability" => context.probability,
+        "derived" => Dict{String,Any}(),
+    )
+end
+
+"""
+    postprocess_samples(postprocessor, sampleset; kwargs...)
+    postprocess_samples(sampleset; kwargs...) do sample, context
+
+Return a new `SampleSet` with raw samples copied unchanged and user-defined
+derived fields attached under `metadata["postprocessing"]`.
+
+The callback receives a copied sample and a context named tuple with `rank`,
+`state`, `raw_value`, `reads`, `probability`, `total_reads`, and the original
+metadata. It must return an `AbstractDict` or `NamedTuple`; keys are stringified
+for serialization-friendly metadata. Callback failures are rethrown as
+`SamplePostprocessingError` so raw quantum results are not silently corrupted.
+"""
+function postprocess_samples(
+    postprocessor::Function,
+    sampleset::QUBOTools.SampleSet{T,U};
+    enabled::Bool = true,
+    name::AbstractString = "anonymous",
+    version = nothing,
+    source_problem = nothing,
+    scoring_convention = nothing,
+    metadata = Dict{String,Any}(),
+) where {T,U}
+    processed = _copied_sampleset(sampleset)
+    enabled || return processed
+
+    aggregate_metadata = _postprocessing_metadata(metadata)
+    source_metadata = deepcopy(QUBOTools.metadata(sampleset))
+    total_reads = sum(QUBOTools.reads(sample) for sample in sampleset; init = 0)
+    rows = Vector{Dict{String,Any}}()
+    sizehint!(rows, length(sampleset))
+
+    for (rank, sample) in enumerate(sampleset)
+        callback_sample = QUBOTools.Sample{T,U}(
+            copy(QUBOTools.state(sample)),
+            QUBOTools.value(sample),
+            QUBOTools.reads(sample),
+        )
+        context = _postprocessing_context(callback_sample, rank, total_reads, source_metadata)
+        row = _postprocessing_row(context)
+
+        derived = try
+            _derived_sample_fields(postprocessor(callback_sample, context))
+        catch err
+            throw(SamplePostprocessingError(rank, callback_sample, err))
+        end
+
+        row["derived"] = derived
+        push!(rows, row)
+    end
+
+    postprocessing = Dict{String,Any}(
+        "enabled" => true,
+        "name" => String(name),
+        "rows" => rows,
+        "row_count" => length(rows),
+        "metadata" => aggregate_metadata,
+    )
+    isnothing(version) || (postprocessing["version"] = string(version))
+    isnothing(source_problem) || (postprocessing["source_problem"] = string(source_problem))
+    isnothing(scoring_convention) ||
+        (postprocessing["scoring_convention"] = string(scoring_convention))
+
+    QUBOTools.metadata(processed)["postprocessing"] = postprocessing
+
+    return processed
+end
+
 function empty_metadata(
     algorithm::AbstractString,
     backend::AbstractString,
@@ -914,7 +1114,7 @@ function quadratic_program(sampler::QUBODrivers.AbstractSampler{T}) where {T}
     return qp.to_ising()
 end
 
-export  VQE, QAOA, check_runtime
+export VQE, QAOA, check_runtime, postprocess_samples, SamplePostprocessingError
 
 include("QAOA.jl")
 include("VQE.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -242,6 +242,146 @@ function expected_maxcut_value(statevector, edges)
     return expected_value
 end
 
+function toy_sampleset()
+    samples = QUBOTools.Sample{Float64,Int}[
+        QUBOTools.Sample{Float64,Int}([1, 0, 1], -2.0, 3),
+        QUBOTools.Sample{Float64,Int}([1, 1, 0], 1.0, 1),
+    ]
+
+    return QUBOTools.SampleSet{Float64,Int}(
+        samples;
+        metadata = Dict{String,Any}(
+            "source" => "toy raw samples",
+            "nested" => Dict{String,Any}("tag" => "raw"),
+        ),
+    )
+end
+
+@testset "Sample postprocessing helper" begin
+    sampleset = toy_sampleset()
+
+    processed = QiskitOpt.postprocess_samples(
+        sampleset;
+        name = "toy_projection",
+        version = v"1.0.0",
+        source_problem = "two-bit original model",
+        scoring_convention = "sum of projected bits",
+        metadata = (schema = "toy-v1",),
+    ) do sample, context
+        state = QUBOTools.state(sample)
+        projected_variables = state[1:2]
+
+        @test context.rank in (1, 2)
+        @test context.state == state
+        @test context.raw_value == QUBOTools.value(sample)
+        @test context.reads == QUBOTools.reads(sample)
+        @test context.total_reads == 4
+        @test context.metadata["nested"]["tag"] == "raw"
+        context.metadata["nested"]["tag"] = "mutated in callback"
+        if context.rank == 1
+            state[1] = 0
+            context.state[2] = 1
+        end
+
+        return (
+            original_objective = sum(projected_variables),
+            feasible = sum(projected_variables) <= 1,
+            projected_variables = projected_variables,
+        )
+    end
+
+    @test processed !== sampleset
+    @test !haskey(QUBOTools.metadata(sampleset), "postprocessing")
+    @test QUBOTools.metadata(sampleset)["nested"]["tag"] == "raw"
+    @test QUBOTools.metadata(processed)["nested"]["tag"] == "raw"
+
+    for index in 1:length(sampleset)
+        @test QUBOTools.state(processed[index]) == QUBOTools.state(sampleset[index])
+        @test QUBOTools.state(processed[index]) !== QUBOTools.state(sampleset[index])
+        @test QUBOTools.value(processed[index]) == QUBOTools.value(sampleset[index])
+        @test QUBOTools.reads(processed[index]) == QUBOTools.reads(sampleset[index])
+    end
+
+    postprocessing = QUBOTools.metadata(processed)["postprocessing"]
+    @test postprocessing["enabled"] == true
+    @test postprocessing["name"] == "toy_projection"
+    @test postprocessing["version"] == "1.0.0"
+    @test postprocessing["source_problem"] == "two-bit original model"
+    @test postprocessing["scoring_convention"] == "sum of projected bits"
+    @test postprocessing["metadata"] == Dict{String,Any}("schema" => "toy-v1")
+    @test postprocessing["row_count"] == 2
+
+    rows = postprocessing["rows"]
+    @test rows[1]["rank"] == 1
+    @test rows[1]["state"] == [1, 0, 1]
+    @test rows[1]["bitstring"] == "101"
+    @test rows[1]["raw_value"] == -2.0
+    @test rows[1]["reads"] == 3
+    @test rows[1]["probability"] == 0.75
+    @test rows[1]["derived"] == Dict{String,Any}(
+        "original_objective" => 1,
+        "feasible" => true,
+        "projected_variables" => [1, 0],
+    )
+    @test rows[2]["derived"]["original_objective"] == 2
+    @test rows[2]["derived"]["feasible"] == false
+    @test rows[2]["probability"] == 0.25
+
+    skipped = QiskitOpt.postprocess_samples(sampleset; enabled=false) do
+        error("disabled postprocessor should not run")
+    end
+    @test !haskey(QUBOTools.metadata(skipped), "postprocessing")
+    @test QUBOTools.state(skipped[1]) == QUBOTools.state(sampleset[1])
+    @test QUBOTools.state(skipped[1]) !== QUBOTools.state(sampleset[1])
+
+    bad_metadata_called = Ref(false)
+    bad_metadata = try
+        QiskitOpt.postprocess_samples(sampleset; metadata=1) do _, _
+            bad_metadata_called[] = true
+            return Dict{String,Any}()
+        end
+    catch err
+        err
+    end
+    @test bad_metadata isa ArgumentError
+    @test !bad_metadata_called[]
+    @test occursin("postprocessing metadata", sprint(showerror, bad_metadata))
+
+    failure = try
+        QiskitOpt.postprocess_samples(sampleset) do _, context
+            context.rank == 1 && return Dict("ok" => true)
+            error("cannot decode sample")
+        end
+    catch err
+        err
+    end
+    @test failure isa QiskitOpt.SamplePostprocessingError
+    @test failure.rank == 2
+    @test occursin("cannot decode sample", sprint(showerror, failure))
+
+    bad_return = try
+        QiskitOpt.postprocess_samples(sampleset) do _, _
+            return 1
+        end
+    catch err
+        err
+    end
+    @test bad_return isa QiskitOpt.SamplePostprocessingError
+    @test bad_return.cause isa ArgumentError
+    @test occursin("AbstractDict or NamedTuple", sprint(showerror, bad_return))
+
+    bad_value = try
+        QiskitOpt.postprocess_samples(sampleset) do _, _
+            return Dict("decoder" => x -> x)
+        end
+    catch err
+        err
+    end
+    @test bad_value isa QiskitOpt.SamplePostprocessingError
+    @test bad_value.cause isa ArgumentError
+    @test occursin("must be serializable", sprint(showerror, bad_value))
+end
+
 @testset "DS-MFG example cached-data smoke" begin
     base_dir = joinpath(@__DIR__, "..", "examples", "ds_mfg_qubo")
     instance = DSMFGQUBOExample.load_instance(base_dir)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -259,6 +259,7 @@ end
 
 @testset "Sample postprocessing helper" begin
     sampleset = toy_sampleset()
+    metadata_snapshot = Ref{Any}(nothing)
 
     processed = QiskitOpt.postprocess_samples(
         sampleset;
@@ -277,7 +278,11 @@ end
         @test context.reads == QUBOTools.reads(sample)
         @test context.total_reads == 4
         @test context.metadata["nested"]["tag"] == "raw"
-        context.metadata["nested"]["tag"] = "mutated in callback"
+        if context.rank == 1
+            metadata_snapshot[] = context.metadata
+        else
+            @test context.metadata === metadata_snapshot[]
+        end
         if context.rank == 1
             state[1] = 0
             context.state[2] = 1


### PR DESCRIPTION
## Summary
- Adds `QiskitOpt.postprocess_samples` for attaching derived per-sample fields to a copied `SampleSet`.
- Records raw state, bitstring, raw QUBO value, reads, and probability alongside derived fields under `metadata["postprocessing"]`.
- Adds explicit `SamplePostprocessingError` failure behavior and recursive serialization-friendly metadata validation.
- Documents a toy projected-objective and feasibility workflow.

## Tests
- PASS: `julia +release --project=. test/runtests.jl`
- NOTE: `julia --project=. test/runtests.jl` on local Julia 1.10.11 fails before test execution in CondaPkg/Pkg initialization with `MethodError: no method matching project_rel_path(::Pkg.Types.EnvCache, ::Nothing)`.

## Branch Hygiene
- Base branch: `main`
- Source branch point: `origin/main` at `a1a4dca8ce7f25e718f84aaa45b5204b8a874a5d`
- Stacked status: not stacked
- Prerequisite PRs: none

Closes #58
