### PR TITLE
Remove direct NumPy pip pin

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -4,7 +4,6 @@ channels = ["conda-forge"]
 python = ">=3.11,<3.12"
 
 [pip.deps]
-numpy               = "~=2.2.0"
 qiskit              = "~=2.3.0"
 qiskit-aer          = "~=0.17.0"
 qiskit-ibm-runtime  = "~=0.46.0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -438,7 +438,9 @@ end
     @test local_diagnostics.packages["qiskit"].ok
     @test local_diagnostics.packages["qiskit_aer"].ok
     @test local_diagnostics.packages["qiskit_optimization"].ok
+    @test local_diagnostics.packages["numpy"].ok
     @test !isnothing(local_diagnostics.packages["qiskit"].version)
+    @test !isnothing(local_diagnostics.packages["numpy"].version)
     @test isnothing(local_diagnostics.ibm_runtime)
     @test !haskey(local_diagnostics.packages, "qiskit_ibm_runtime")
     @test !isnothing(local_diagnostics.local_backend)


### PR DESCRIPTION
## Summary

- Remove QiskitOpt's direct `numpy ~=2.2.0` pip dependency so Qiskit/SciPy and co-installed packages can drive the NumPy resolver policy.
- Keep the runtime diagnostics smoke explicit by asserting that NumPy imports successfully and exposes a version.

Closes #63.

## Tests

- Reproduced the pre-fix shared resolver failure with local `QiskitOpt` plus registered `DWave v0.7.2`: CondaPkg generated `numpy = "==2.4.6,~=2.2.0"` and pixi failed with `you require numpy empty`.
- Verified the edited shared resolver path with local `QiskitOpt` plus registered `DWave v0.7.2`: CondaPkg generated `numpy = "==2.4.6"` and pixi installed the environment successfully.
- `julia --project=@. -e 'using Pkg; repo = pwd(); dir = mktempdir(); Pkg.activate(dir); Pkg.develop(PackageSpec(path=repo)); Pkg.test("QiskitOpt"; coverage=false)'`

## Branch Hygiene

- Base branch: `main`
- Source branch: `fix/issue-63-numpy-bound`
- Source branch point: `origin/main` at `d0db6c1bcb1a78cf35f149cacc4ff02f18e7cc8d`
- Stacked status: not stacked
- Prerequisite PRs: none
