### PR TITLE
Release v0.7.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QiskitOpt"
 uuid = "81b20daf-e62b-4502-a0d1-aa084de80e33"
 authors = ["pedromxavier <pedroxavier@psr-inc.com>", "pedroripper <pedroripper@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"


### PR DESCRIPTION
## Summary

- Bump QiskitOpt.jl from `0.7.0` to `0.7.1`.

## Release Notes

### Breaking changes

- No breaking changes.

### Changes

- Remove QiskitOpt's direct `numpy ~=2.2.0` pip pin and let the Qiskit/SciPy stack or co-installed packages drive the NumPy resolver policy.
- Add an explicit NumPy runtime diagnostics smoke assertion.

### Compatibility note

- JuliaQUBO/DWave.jl v0.7.3 is now registered with `numpy ~=2.2.0`, so the original DWave/QiskitOpt benchmark conflict no longer depends on this QiskitOpt release alone.
- This patch still publishes QiskitOpt's relaxed direct NumPy policy for other shared CondaPkg environments.

## Tests

- `git diff --check` passed.
- `julia +release --project=. -e 'import Pkg; Pkg.test()'` passed.
- `julia +release --project=@. -e 'using Pkg; Pkg.Registry.update(); repo = pwd(); dir = mktempdir(); Pkg.activate(dir); Pkg.develop(PackageSpec(path=repo)); Pkg.add(PackageSpec(name="DWave", version=v"0.7.3")); Pkg.add("CondaPkg"); import CondaPkg; CondaPkg.resolve()'` passed and generated `numpy = "~=2.2.0"` from DWave v0.7.3 in the combined CondaPkg environment.

## Branch Hygiene

- Base branch: `main`
- Source branch: `release/v0.7.1`
- Source branch point: `271a2cea36f54f654df36f69090c267449b7ec8d` (`origin/main`)
- Stacked status: not stacked
- Prerequisite PRs: none
