### PR TITLE
Standardize optional Julia workflow caching

### DIFF
--- a/.github/workflows/dependency-drift.yml
+++ b/.github/workflows/dependency-drift.yml
@@ -16,5 +16,6 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/ibm-hardware-smoke.yml
+++ b/.github/workflows/ibm-hardware-smoke.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
+      - uses: julia-actions/cache@v3
       - name: Check IBM runtime configuration
         id: config
         shell: bash


### PR DESCRIPTION
## Summary

- Add `julia-actions/cache@v3` to the optional Dependency Drift workflow.
- Add `julia-actions/cache@v3` to the optional IBM Hardware Smoke workflow.
- Leave the package-test CI matrix and Dependabot cadence unchanged because they already match the Wave 2 baseline.

Closes #67

## Baseline Notes

- `CI` already tests Julia `1.10` and `1` on `ubuntu-latest`, plus Julia `1` on `windows-latest`.
- Dependabot already covers Julia weekly and GitHub Actions monthly.
- The optional drift and hardware smoke workflows remain non-blocking via `continue-on-error: true`.
- Remaining drift: none identified for this repository. `test/Project.toml` contains only stdlibs, so no extra Dependabot Julia directory was added.

## Local Checks

- `git diff --check`
- `actionlint .github/workflows/*.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/dependency-drift.yml .github/workflows/ibm-hardware-smoke.yml .github/workflows/tagbot.yml .github/dependabot.yml`

## Branch Hygiene

- Base branch: `main`
- Source branch: `fix/issue-67-ci-dependabot-baseline`
- Branch point: `origin/main` at `36b9ec9`
- Stacked status: not stacked
- Prerequisite PRs: none
